### PR TITLE
Add instructions for migrating the database in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ First, install docker and docker-compose. Then navigate to `envs/dev` and run `d
 
 Next, crate the docker volumes where persistent data will be stored.  `docker volume create --name=vol_smart_pgdata` and `docker volume create --name=vol_smart_data`.
 
+Then, migrate the database to ensure the schema is prepared for the application. `docker-compose run --rm smart_backend ./migrate.sh`.
+
 ### Workflow During Development
 
 Run `docker-compose up` to start all docker containers.  This will start up the containers in the foreground so you can see the logs.  If you prefer to run the containers in the background use `docker-compose up -d`. When switching between branches there is no need to run any additional commands (except build if there is dependency change).

--- a/smart-docs/docs/index.rst
+++ b/smart-docs/docs/index.rst
@@ -21,6 +21,7 @@ Quick Start
 	$ docker-compose build
 	$ docker volume create --name=vol_smart_pgdata
 	$ docker volume create --name=vol_smart_data
+  $ docker-compose run --rm smart_backend ./migrate.sh
 	$ docker-compose up -d
 
 Open your browser to http://localhost:8000

--- a/smart-docs/docs/tutorial-installation.rst
+++ b/smart-docs/docs/tutorial-installation.rst
@@ -24,6 +24,12 @@ Next, create the docker volumes where persistent data will be stored: ``docker v
 	$ docker volume create --name=vol_smart_pgdata
 	$ docker volume create --name=vol_smart_data
 
+Then, setup the database and ensure the correct table/schema is prepared for the application
+
+::
+
+  $ docker-compose run --rm smart_backend ./migrate.sh
+
 Lastly, run ``docker-compose up`` to start all docker containers.  This will start up the containers in the foreground so you can see the logs.  If you prefer to run the containers in the background use ``docker-compose up -d``. When switching between branches there is no need to run any additional commands (except build if there is dependency change).
 
 ::

--- a/smart-docs/docs/tutorial-installation.rst
+++ b/smart-docs/docs/tutorial-installation.rst
@@ -24,7 +24,7 @@ Next, create the docker volumes where persistent data will be stored: ``docker v
 	$ docker volume create --name=vol_smart_pgdata
 	$ docker volume create --name=vol_smart_data
 
-Then, setup the database and ensure the correct table/schema is prepared for the application
+Then, migrate the database to ensure the schema is prepared for the application.
 
 ::
 


### PR DESCRIPTION
Both the user-documentation and repo readme where missing the instruction to migrate the database before starting the server.