### PR TITLE
Multiline text support

### DIFF
--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -34,13 +34,23 @@ def clean_data_helper(data, supplied_labels):
 
     try:
         if data.content_type == 'text/tab-separated-values':
-            data = pd.read_csv(StringIO(data.read().decode('utf8', 'ignore')), sep='\t').dropna(axis=0, how="all")
+            data = pd.read_csv(
+                StringIO(data.read().decode('utf8', 'ignore')),
+                sep='\t',
+                dtype=str,
+            ).dropna(axis=0, how="all")
         elif data.content_type == 'text/csv':
-            data = pd.read_csv(StringIO(data.read().decode('utf8', 'ignore'))).dropna(axis=0, how="all")
+            data = pd.read_csv(
+                StringIO(data.read().decode('utf8', 'ignore')),
+                dtype=str,
+            ).dropna(axis=0, how="all")
         elif data.content_type.startswith('application/vnd') and data.name.endswith('.csv'):
-            data = pd.read_csv(StringIO(data.read().decode('utf8', 'ignore'))).dropna(axis=0, how="all")
+            data = pd.read_csv(
+                StringIO(data.read().decode('utf8', 'ignore')),
+                dtype=str,
+            ).dropna(axis=0, how="all")
         elif data.content_type.startswith('application/vnd') and data.name.endswith('.xlsx'):
-            data = pd.read_excel(data).dropna(axis=0, how="all")
+            data = pd.read_excel(data, dtype=str).dropna(axis=0, how="all")
         else:
             raise ValidationError("File type is not supported.  Received {0} but only {1} are supported."
                                   .format(data.content_type, ', '.join(ALLOWED_TYPES)))

--- a/backend/django/core/tasks.py
+++ b/backend/django/core/tasks.py
@@ -50,7 +50,7 @@ def send_tfidf_creation_task(project_pk):
 
 @shared_task
 def send_check_and_trigger_model_task(project_pk):
-    from core.util.utils_model import check_and_trigger_model
+    from core.utils.utils_model import check_and_trigger_model
     from core.models import Data
 
     datum = Data.objects.filter(project=project_pk).first()

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -106,7 +106,9 @@ def create_data_from_csv(df, project):
 
     # Replace tabs since thats our delimiter, remove carriage returns since copy_from doesnt like them
     # escape all backslashes because it seems to fix "end-of-copy marker corrupt"
-    df['Text'] = df['Text'].apply(lambda x: x.replace('\t', '').replace('\r', '').replace('\\', '\\\\'))
+    df['Text'] = df['Text'].apply(lambda x:
+        x.replace('\t', ' ').replace('\r', ' ').replace('\n', ' ').replace('\\', '\\\\')
+    )
 
     df.to_csv(stream, sep='\t', header=False, index=False, columns=columns)
     stream.seek(0)

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -106,8 +106,8 @@ def create_data_from_csv(df, project):
 
     # Replace tabs since thats our delimiter, remove carriage returns since copy_from doesnt like them
     # escape all backslashes because it seems to fix "end-of-copy marker corrupt"
-    df['Text'] = df['Text'].apply(lambda x:
-        x.replace('\t', ' ').replace('\r', ' ').replace('\n', ' ').replace('\\', '\\\\')
+    df['Text'] = df['Text'].apply(
+        lambda x: x.replace('\t', ' ').replace('\r', ' ').replace('\n', ' ').replace('\\', '\\\\')
     )
 
     df.to_csv(stream, sep='\t', header=False, index=False, columns=columns)


### PR DESCRIPTION
Addresses #7

* Postgres copy_from does not like newline characters (since its expects each line from the csv to correspond to one row in the database, and the newlines in the text are not being escaped correctly).  We already remove tabs and return characters ("\t" and "\r" respectively).  So just replace new lines as well.

* Additionally the UI would not render the new lines anyway, so removing them seems reasonable.

* A separate issue was that if labels were "int-like" then pandas casted them to int and if there was an error in the form-clean function it was unable to join the labels together to form a string.  Just tell pandas to cast the entire dataframe to string.

* Finally there was a typo in a task import.


Tested the multiline import with a test.csv with the following contents

```
Text,Label
"Line1
Line2",1
"Line3
Line4",2
"Line5
Line6",
```