### PR TITLE
Bump up the docker python version from 3.5.3 to 3.5.7

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.5.3
+FROM python:3.5.7
 ENV PYTHONUNBUFFERED 1
 RUN apt-get update && apt-get install -y netcat-traditional
 WORKDIR /code
 ADD ./requirements.txt /code/requirements.txt
-RUN pip install --use-wheel -r requirements.txt
+RUN pip install -r requirements.txt
 RUN mkdir -p /data/data_files /data/tf_idf /data/model_pickles /data/code_books
 EXPOSE 8000

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,9 +1,9 @@
-FROM python:3.5.3
+FROM python:3.5.7
 ENV PYTHONUNBUFFERED 1
 RUN apt-get update && apt-get install -y netcat-traditional mysql-client
 WORKDIR /code
 ADD ./requirements.txt /code/requirements.txt
-RUN pip install --use-wheel -r requirements.txt
+RUN pip install  -r requirements.txt
 RUN pip install gunicorn
 ADD ./smart/ /code/
 RUN mkdir -p /data/data_files /data/tf_idf /data/model_pickles /data/code_books

--- a/backend/django/core/data/Dockerfile
+++ b/backend/django/core/data/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5.3
+FROM python:3.5.7
 WORKDIR /code
 ADD ./requirements.txt /code/requirements.txt
 RUN pip install --upgrade pip && pip install -r requirements.txt


### PR DESCRIPTION
Addresses #11 

3.5.3 is no longer supported and used debian-jessie as its dependency.
Jessie repostitories have been archived, so apt-get fails