### PR TITLE
Update psycopg2 to fix issue with the docker image

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,7 +32,7 @@ openapi-codec==1.3.1
 openpyxl==2.5.5
 pandas==0.20.3
 patsy==0.5.0
-psycopg2==2.7.1
+psycopg2==2.8.3
 py==1.4.34
 pycodestyle==2.0.0
 pytest==3.1.2


### PR DESCRIPTION
See https://github.com/psycopg/psycopg2-wheels/issues/2

I had the same error when running `docker-compose up`.