### PR TITLE
Fix bug annotate

### DIFF
--- a/frontend/src/actions/card.js
+++ b/frontend/src/actions/card.js
@@ -57,7 +57,6 @@ export const annotateCard = (
     labelID,
     labelReason,
     num_cards_left,
-    is_explicit,
     projectID,
     is_admin
 ) => {
@@ -65,7 +64,6 @@ export const annotateCard = (
         labelID: labelID,
         labeling_time: moment().diff(card['start_time'], 'seconds'), // now - start_time rounded to whole seconds
         labelReason: labelReason,
-        is_explicit: is_explicit
     };
     let apiURL = `/api/annotate_data/${card.pk}/`;
     return dispatch => {

--- a/frontend/src/components/AdminTable/index.jsx
+++ b/frontend/src/components/AdminTable/index.jsx
@@ -32,6 +32,7 @@ class AdminTable extends React.Component {
                         reason: datum.label_reason,
                         is_explicit: datum.is_explicit
                     }}
+                    labelingTab="admin"
                 />
             </div>
         );

--- a/frontend/src/components/Card/index.jsx
+++ b/frontend/src/components/Card/index.jsx
@@ -34,6 +34,7 @@ class Card extends React.Component {
                             labels={labels}
                             optionalInt={cards.length}
                             hasExplicit = {hasExplicit}
+                            labelingTab="annotate"
                         />
                     </div>
                 </div>

--- a/frontend/src/components/History/index.jsx
+++ b/frontend/src/components/History/index.jsx
@@ -40,6 +40,7 @@ class History extends React.Component {
                         discardFunction={() => {}}
                         labels={labels}
                         hasExplicit={hasExplicit}
+                        labelingTab="history"
                     />
                 </div>
             );

--- a/frontend/src/components/LabelForm/index.jsx
+++ b/frontend/src/components/LabelForm/index.jsx
@@ -136,7 +136,8 @@ class LabelForm extends React.Component {
             });
             event.preventDefault();
         } else {
-            if (this.props.optionalInt != null) {
+
+            if (this.props.labelingTab == "annotate") {
                 this.props.skipFunction(
                     this.props.data,
                     this.state.selected_label.pk,
@@ -144,17 +145,10 @@ class LabelForm extends React.Component {
                     this.props.optionalInt,
                     this.state.is_explicit
                 );
-            } else if (this.props.previousLabel != null) {
+            } else if (this.props.labelingTab == "history") {
                 this.props.skipFunction(
                     this.props.data,
                     this.props.previousLabel.pk,
-                    this.state.selected_label.pk,
-                    this.state.label_reason,
-                    this.state.is_explicit
-                );
-            } else {
-                this.props.skipFunction(
-                    this.props.data,
                     this.state.selected_label.pk,
                     this.state.label_reason,
                     this.state.is_explicit
@@ -166,14 +160,14 @@ class LabelForm extends React.Component {
 
     annotateData() {
         /* This function handles the logic for calling annotate functions*/
-        if (this.props.optionalInt != null) {
+        if (this.props.labelingTab == "annotate") {
             this.props.labelFunction(
                 this.props.data,
                 this.state.selected_label.pk,
                 this.state.label_reason,
                 this.props.optionalInt
             );
-        } else if (!this.props.passButton) {
+        } else if (this.props.labelingTab == "admin") {
             // If this is the admin table which does not have skipping
             this.props.labelFunction(
                 this.props.data,
@@ -181,7 +175,7 @@ class LabelForm extends React.Component {
                 this.state.label_reason,
                 this.state.is_explicit
             );
-        } else if (this.props.previousLabel != null) {
+        } else if (this.props.labelingTab == "history") {
             // If this is the history table
             this.props.labelFunction(
                 this.props.data,
@@ -189,7 +183,7 @@ class LabelForm extends React.Component {
                 this.state.selected_label.pk,
                 this.state.label_reason
             );
-        } else {
+        } else if (this.props.labelingTab == "skew") {
             // this is the skew table
             this.props.labelFunction(
                 this.props.data,
@@ -335,7 +329,8 @@ LabelForm.propTypes = {
     discardFunction: PropTypes.func.isRequired,
     labels: PropTypes.arrayOf(PropTypes.object),
     optionalInt: PropTypes.integer,
-    hasExplicit: PropTypes.boolean
+    hasExplicit: PropTypes.boolean,
+    labelingTab: PropTypes.string
 };
 
 export default LabelForm;

--- a/frontend/src/components/Skew/index.jsx
+++ b/frontend/src/components/Skew/index.jsx
@@ -74,6 +74,7 @@ class Skew extends React.Component {
                             skipFunction={() => {}}
                             discardFunction={() => {}}
                             labels={labels}
+                            labelingTab="skew"
                         />
                     </div>
                 );


### PR DESCRIPTION
This branch fixes a bug with the annotate call. In the annotate page, the skip function is supposed to send the explicit indicator but the annotate function is not. In the action for annotate, it was expecting the explicit indicator for some reason.

In addition, I made the conditionals which choose which set of arguments to pass to the skip or annotate function (since four different sources use labelform slightly differently) more straightforward by having the calling object pass its name.