### PR TITLE
Add newline display to project descriptions and annotation cards

### DIFF
--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -41,12 +41,12 @@ def clean_data_helper(data, supplied_labels):
             ).dropna(axis=0, how="all")
         elif data.content_type == 'text/csv':
             data = pd.read_csv(
-                StringIO(data.read().decode('utf8', 'ignore')),
+                StringIO(data.read().decode('utf8', 'ignore'), newline=None),
                 dtype=str,
             ).dropna(axis=0, how="all")
         elif data.content_type.startswith('application/vnd') and data.name.endswith('.csv'):
             data = pd.read_csv(
-                StringIO(data.read().decode('utf8', 'ignore')),
+                StringIO(data.read().decode('utf8', 'ignore'), newline=None),
                 dtype=str,
             ).dropna(axis=0, how="all")
         elif data.content_type.startswith('application/vnd') and data.name.endswith('.xlsx'):

--- a/backend/django/core/templates/projects/detail.html
+++ b/backend/django/core/templates/projects/detail.html
@@ -25,7 +25,7 @@
           <div id="description-panel" class="panel-collapse collapse in">
             <div class="panel-body">
               {% if project.description %}
-              <p>{{ project.description }}</p>
+              <p>{{ project.description | linebreaks }}</p>
               {% else %}
               <h5><strong>No Description Available</strong></h5>
               {% endif %}

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -104,18 +104,26 @@ def create_data_from_csv(df, project):
     df['project'] = project.pk
     df['irr_ind'] = False
 
-    # Replace tabs since thats our delimiter, remove carriage returns since copy_from doesnt like them
-    # escape all backslashes because it seems to fix "end-of-copy marker corrupt"
+    # Replace tabs since thats our delimiter, escape all backslashes because it seems to 
+    # fix "end-of-copy marker corrupt"
     df['Text'] = df['Text'].apply(
-        lambda x: x.replace('\t', ' ').replace('\r', ' ').replace('\n', ' ').replace('\\', '\\\\')
+        lambda x: x.replace('\t', ' ').replace('\\', '\\\\')
     )
 
     df.to_csv(stream, sep='\t', header=False, index=False, columns=columns)
+    stream_length = stream.tell()
     stream.seek(0)
 
     with connection.cursor() as c:
-        c.copy_from(stream, Data._meta.db_table, sep='\t', null='',
-                    columns=['text', 'project_id', 'hash', 'upload_id', 'upload_id_hash', 'irr_ind'])
+        # We must use copy_expert with raw SQL in order to avoid removing newlines - which limits cards considerably
+        sql = """COPY {} (text, project_id, hash, upload_id, upload_id_hash, irr_ind) 
+                 FROM stdin WITH (FORMAT 'csv', DELIMITER E'\\t')
+              """.format(Data._meta.db_table)
+        c.copy_expert(
+            sql,
+            stream,
+            stream_length,
+        )
 
 
 def create_labels_from_csv(df, project):

--- a/frontend/src/components/Card/index.jsx
+++ b/frontend/src/components/Card/index.jsx
@@ -21,7 +21,11 @@ class Card extends React.Component {
                 <div className="full" key={cards[0].id}>
                     <div className="cardface">
                         <h2>Card {cards[0].id + 1}</h2>
-                        <p>{ cards[0].text['text'] }</p>
+                        <p>{ cards[0].text['text'].split(/\r?\n/).map(
+                            (item, key) => { 
+                                return <span key={key}>{item}<br/></span>;
+                            }) 
+                        }</p>
                         <ButtonToolbar bsClass="btn-toolbar pull-right">
                             {labels.map( (opt) => (
                                 <Button onClick={() => annotateCard(cards[0], opt['pk'], cards.length, ADMIN)}


### PR DESCRIPTION
Fixed #46. I need to display formatted content, and this requires that I have newlines for my project description, tag/label descriptions and especially the annotation cards themselves.

The project detail template had to be altered to use the `linebreaks` option for the description. This was the only change required to make this work.

To make the cards use newlines, I had to alter both front-end and back-end components. 

* I had to alter the `StringIO` wrapper around the form to use the `newline=None` parameter for CSV/TSV types.
* I removed the stripping of `\n` and `\r` from the backend `django.core.utils.util.create_data_from_csv` method.
* I then used `connection.cursor.copy_expert` with a raw SQL string I created that uses the `COPY FROM stdin WITH (FORMAT 'csv', DELIMITER E'\\t'` function of Postgres. It was not possible to generate the field list, since `Data._meta.get_fields()` returns more than the fields we need.
* I had to convert any `\n` or `\r` characters in the React card template into `<br />`s, since newlines have no effect in HTML. The clean way to do this was to wrap each line of texts into its own `<span>text<br/></span>`, so that is what I did.

That was it! Now you can more richly format project descriptions and cards :)