### PR TITLE
fix: Filtering a sliced query in fleiss_kappa

### DIFF
--- a/backend/django/core/utils/utils_model.py
+++ b/backend/django/core/utils/utils_model.py
@@ -119,7 +119,10 @@ def fleiss_kappa(project):
                 l_label = "skip"
             else:
                 l_label = str(l)
-            label_count_dict[l_label] = len(d_data_log.filter(label__name=l))
+
+            labels_filtered = list(filter(lambda x: x.label.name == l_label,
+                                          d_data_log))
+            label_count_dict[l_label] = len(labels_filtered)
 
         data_label_dict.append(label_count_dict)
 


### PR DESCRIPTION
* The `fleiss_kappa` function retrieves objects from the IRRLog in order
  to compute the Fleiss Kappa. If the number of retrieved objects is
  larger than the number of labelers (n), the retrieved objects are
  sliced to be at most n in size.

  This, however, leads to the "Cannot filter a query once a slice has
  been taken" error and a 500 response.

* This commit fixes the situation by filtering the retrieved IRRLog
  objects directly in Python instead of doing it on the ORM level.

Signed-off-by: mr.Shu <mr@shu.io>