### PR TITLE
Fixed quick start instructions

### DIFF
--- a/smart-docs/docs/index.rst
+++ b/smart-docs/docs/index.rst
@@ -17,7 +17,7 @@ Quick Start
 ::
 
 	$ git clone https://github.com/RTIInternational/SMART.git
-	$ cd smart/envs/dev/
+	$ cd SMART/envs/dev/
 	$ docker-compose build
 	$ docker volume create --name=vol_smart_pgdata
 	$ docker volume create --name=vol_smart_data


### PR DESCRIPTION
The project is cloned into SMART folder

The following command failed
`cd smart/envs/dev/`

It was changed to
`cd SMART/envs/dev/`