### PR TITLE
Chore: Update node version to 8

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:8
 RUN mkdir /code
 ADD ./package.json /code/package.json
 ADD ./yarn.lock /code/yarn.lock


### PR DESCRIPTION
This was due to a conflict with a sub-package `cross-spawn`

Trying to run through the documented docker quickstart and received the following error:
```
error cross-spawn@7.0.3: The engine "node" is incompatible with this module. Expected version ">= 8". Got "6.17.1"
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
error Found incompatible module
ERROR: Service 'smart_frontend' failed to build : The command '/bin/sh -c yarn add --force node-sass' returned a non-zero code: 1
```

So bumped the node container version and it succeeded. 