### PR TITLE
improve label display for admin distribution chart

### DIFF
--- a/backend/django/core/templates/projects/admin/admin_label.html
+++ b/backend/django/core/templates/projects/admin/admin_label.html
@@ -1,13 +1,13 @@
 {% block label_tab %}
 <div id="label" class="tab-pane fade in active">
   <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-12">
       <h3>Label Distribution</h3>
-      <div id="distribution_chart" style="height:300px">
+      <div id="distribution_chart" style="height:400px">
         <svg class="nvd3-svg"></svg>
       </div>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-12">
       <h3>Time To Label</h3>
       <div id="timer_chart" style="height:300px">
         <svg class="nvd3-svg"></svg>


### PR DESCRIPTION
This affects the distribution chart on the admin page:

- Label legend is now on the bottom of the chart
- Both distribution and time chart span the entire width
- The top N (currently = 5) labels are displayed in the legend, along with a final "other labels" tab