### PR TITLE
add label dropdown description to placeholder on history data cards

### DIFF
--- a/frontend/src/components/History/index.jsx
+++ b/frontend/src/components/History/index.jsx
@@ -146,7 +146,7 @@ class History extends React.Component {
                                     )
                                 }
                                 options={labelsOptions}
-                                placeholder="Select label..."
+                                placeholder={labelsOptions.find(labelOption => labelOption.name.includes(row.original.old_label)).dropdownLabel}
                                 searchBy="dropdownLabel"
                                 sortBy="dropdownLabel"
                                 style={{ minWidth: "200px" }}

--- a/frontend/src/components/History/index.jsx
+++ b/frontend/src/components/History/index.jsx
@@ -146,7 +146,7 @@ class History extends React.Component {
                                     )
                                 }
                                 options={labelsOptions}
-                                placeholder={labelsOptions.find(labelOption => labelOption.name.includes(row.original.old_label)).dropdownLabel}
+                                placeholder={labelsOptions.find(labelOption => labelOption.name === row.original.old_label).dropdownLabel}
                                 searchBy="dropdownLabel"
                                 sortBy="dropdownLabel"
                                 style={{ minWidth: "200px" }}

--- a/frontend/src/styles/smart.scss
+++ b/frontend/src/styles/smart.scss
@@ -192,6 +192,34 @@ main {
         }
     }
 
+    .react-dropdown-select-content {
+        width: 100%;
+
+        @include breakpoint(medium) {
+            width: 300px;
+        }
+
+        @include breakpoint(large) {
+            width: 400px;
+        }
+    }
+
+    .react-dropdown-select-input {
+        width: 95%;
+
+        @include breakpoint(medium) {
+            width: 280px;
+        }
+
+        @include breakpoint(large) {
+            width: 380px;
+        }
+    }
+
+    .react-dropdown-select-input::placeholder {
+        text-overflow: ellipsis;
+    }
+
     .ajucate-button {
         flex: 0 0 auto;
     }


### PR DESCRIPTION
This adds the current label and description to the placeholder on the dropdown/search for data cards on the history tab