### PR TITLE
remove default batch selection from create page

### DIFF
--- a/backend/django/core/templates/projects/create/create_wizard_advanced.html
+++ b/backend/django/core/templates/projects/create/create_wizard_advanced.html
@@ -113,9 +113,6 @@
               </div>
               <div id="b-panel" class="panel-collapse collapse show">
                 <div class="panel-body">
-                  <div id="use_default_size">
-                    Use default size (10 times the number of labels): {{ wizard.form.use_default_batch_size}}
-                  </div>
                   <div id="choose_batch_size">
                     Batch size (must be between 10 and 1000): {{ wizard.form.batch_size}}
                   </div>


### PR DESCRIPTION
This removes the default batch option in the project create form and instead just has an input for the user to determine the batch size (as opposed to defaulting to 10 times the number of labels.) 

The default value in the input still starts at 30.