### PR TITLE
add project status badge

### DIFF
--- a/backend/django/core/templates/projects/list.html
+++ b/backend/django/core/templates/projects/list.html
@@ -25,6 +25,7 @@
                     {% if project.umbrella_string == potential_umbrella_project.umbrella_string %}
                       <tr>
                         <td>{{ project.name }}</td>
+                        <td><div class="project_status_badge">{{ project.project_details.badge }}</div></td>
                         <td><a href="{{ project.get_absolute_url }}">Details</a></td>
                         <td><a href="{% url 'projects:project_code' project.pk %}">Annotate</a></td>
                         {% if project|proj_permission_level:request.user.profile > 1 %}
@@ -65,6 +66,7 @@
                   {% if not project.umbrella_string %}
                     <tr>
                       <td>{{ project.name }}</td>
+                      <td><div class="project_status_badge">{{ project.project_details.badge }}</div></td>
                       <td><a href="{{ project.get_absolute_url }}">Details</a></td>
                       <td><a href="{% url 'projects:project_code' project.pk %}">Annotate</a></td>
                       {% if project|proj_permission_level:request.user.profile > 1 %}

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -14,9 +14,11 @@ from string_grouper import compute_pairwise_similarities
 
 from core import tasks
 from core.models import (
+    AssignedData,
     Data,
     DataLabel,
     DataLabelSimilarityPairs,
+    DataQueue,
     IRRLog,
     Label,
     MetaData,
@@ -24,6 +26,7 @@ from core.models import (
     Profile,
     Project,
     ProjectPermissions,
+    RecycleBin,
     TrainingSet,
 )
 from core.utils.utils_queue import fill_queue
@@ -571,3 +574,48 @@ def get_labeled_data(project):
     label_frame = pd.DataFrame(labels)
 
     return labeled_data_frame, label_frame
+
+
+def project_status(project):
+    """This returns data information.
+
+    Args:
+        project
+    Returns:
+        data: a list of data information
+    """
+    total_data_objs = project.data_set.all()
+
+    final_data_objs = list(
+        DataLabel.objects.filter(data__project=project, data__irr_ind=False)
+    )
+
+    stuff_in_irrlog = IRRLog.objects.filter(data__project=project).values_list(
+        "data__pk", flat=True
+    )
+    stuff_in_queue = DataQueue.objects.filter(
+        queue__project=project, queue__type="admin"
+    ).values_list("data__pk", flat=True)
+    recycle_ids = RecycleBin.objects.filter(data__project=project).values_list(
+        "data__pk", flat=True
+    )
+    assigned_ids = AssignedData.objects.filter(data__project=project).values_list(
+        "data__pk", flat=True
+    )
+    unlabeled_data_objs = list(
+        project.data_set.filter(datalabel__isnull=True)
+        .exclude(id__in=stuff_in_queue)
+        .exclude(id__in=stuff_in_irrlog)
+        .exclude(id__in=assigned_ids)
+        .exclude(id__in=recycle_ids)
+    )
+
+    return {
+        "adjudication": len(stuff_in_queue),
+        "assigned": len(assigned_ids),
+        "final": len(final_data_objs),
+        "recycled": len(recycle_ids),
+        "total": len(total_data_objs),
+        "unlabeled": len(unlabeled_data_objs),
+        "badge": f"{len(total_data_objs) - len(unlabeled_data_objs)}/{len(unlabeled_data_objs)}",
+    }

--- a/backend/django/core/views/frontend.py
+++ b/backend/django/core/views/frontend.py
@@ -24,7 +24,7 @@ from core.forms import (
 )
 from core.models import Data, Label, MetaDataField, Project, TrainingSet
 from core.templatetags import project_extras
-from core.utils.util import save_codebook_file, upload_data
+from core.utils.util import project_status, save_codebook_file, upload_data
 from core.utils.utils_annotate import batch_unassign
 from core.utils.utils_queue import add_queue, find_queue_length
 
@@ -100,7 +100,12 @@ class ProjectList(LoginRequiredMixin, ListView):
 
         qs = qs1 | qs2
 
-        return qs.distinct().order_by(self.ordering).reverse()
+        projects = qs.distinct().order_by(self.ordering).reverse()
+        for project in projects:
+            project_details = project_status(project)
+            project.project_details = project_details
+
+        return projects
 
 
 class ProjectDetail(LoginRequiredMixin, UserPassesTestMixin, DetailView):

--- a/frontend/src/styles/smart.scss
+++ b/frontend/src/styles/smart.scss
@@ -540,3 +540,14 @@ li.disabled {
     border: 1px solid lightgrey;
     padding-left: 10px;
 }
+
+.project_status_badge {
+    padding: 4px;
+    background-color: #E6F5EB;
+    // border: 1px solid #E4D375;
+    // border: 1px solid #DDDDDD;
+    border-radius: 4px;
+    color: #62AF7C;
+    font-size: 14px;
+    width: fit-content;
+}


### PR DESCRIPTION
This adds project status badges to the project list page.

It moves the logic to get the project status to utils, and also changes the old details page to get the status from this new utils function