### PR TITLE
add gitattributes file which should keep line endings as LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# for all .sh files, make sure they use lf line endings
+*.sh text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf


### PR DESCRIPTION
This branch looks to ensure that windows users can checkout SMART without the line endings breaking in places that will cause problems. This mainly impacts bash files and frontend files.

