### PR TITLE
handle more than 2000 labels when updating descriptions

### DIFF
--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -293,7 +293,12 @@ LabelFormSet = forms.inlineformset_factory(
     absolute_max=10000,
 )
 LabelDescriptionFormSet = forms.inlineformset_factory(
-    Project, Label, form=LabelDescriptionForm, can_delete=False, extra=0
+    Project,
+    Label,
+    form=LabelDescriptionForm,
+    can_delete=False,
+    extra=0,
+    absolute_max=10000,
 )
 PermissionsFormSet = forms.inlineformset_factory(
     Project, ProjectPermissions, form=ProjectPermissionsForm, extra=1, can_delete=True

--- a/backend/django/core/templates/projects/create/create_wizard_labels.html
+++ b/backend/django/core/templates/projects/create/create_wizard_labels.html
@@ -35,6 +35,7 @@
           <ul class="list-group">
             <li class="list-group-item">SMART <strong>requires at least two category labels</strong> and the labels must be <strong>unique</strong>.</li>
             <li class="list-group-item">If you plan on uploading a data file that contains labels, the label categories in the file must match those provided on this page.</li>
+            <li class="list-group-item">You may add up to 10,000 labels to each project.</li>
             <li class="list-group-item">You cannot update the labels for a project after the project is created.</li>
           </ul>
           <div class="form-group">

--- a/backend/django/core/views/frontend.py
+++ b/backend/django/core/views/frontend.py
@@ -756,9 +756,9 @@ class ProjectUpdateLabel(LoginRequiredMixin, UserPassesTestMixin, View):
                 labels.instance = context["project"]
                 labels.save()
 
-                update_label_embeddings(context["project"])
+            update_label_embeddings(context["project"])
 
-                return redirect(self.get_success_url())
+            return redirect(self.get_success_url())
         else:
             return self.render_to_response(context)
 

--- a/smart-docs/docs/tutorial-new-project.rst
+++ b/smart-docs/docs/tutorial-new-project.rst
@@ -31,6 +31,7 @@ In the Labels section, we will create categories for labeling. These labeled obs
 
 	* SMART requires at least two category labels and the labels must be unique.
 	* If you plan on uploading a data file that contains labels, the label categories in the file must match those provided on this page.
+	* You may add up to 10,000 labels to each project.
 
 .. warning::
 	* You cannot add, remove, or update any labels for a project after the project is created.


### PR DESCRIPTION
The default max size of a form is 2,000 according to the Django docs, this adds a max limit of 10,000 so that we can update projects with many labels.

Django docs: https://docs.djangoproject.com/en/4.0/topics/forms/formsets/#limiting-the-maximum-number-of-instantiated-forms