### PR TITLE
enable skew to handle large projects

### DIFF
--- a/backend/django/core/urls/api.py
+++ b/backend/django/core/urls/api.py
@@ -45,6 +45,10 @@ annotate_patterns = [
         r"^data_unlabeled_table/(?P<project_pk>\d+)/$",
         api_annotate.data_unlabeled_table,
     ),
+    re_path(
+        r"^search_data_unlabeled_table/(?P<project_pk>\d+)/$",
+        api_annotate.search_data_unlabeled_table,
+    ),
     re_path(r"^get_card_deck/(?P<project_pk>\d+)/$", api_annotate.get_card_deck),
     re_path(
         r"^recycle_bin_table/(?P<project_pk>\d+)/$", api_annotate.recycle_bin_table

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -428,19 +428,16 @@ def data_unlabeled_table(request, project_pk):
     Returns:
         data: a list of data information
     """
-    unlabeled_data = get_unlabeled_data(project_pk)
-    data = []
-    for d in unlabeled_data:
-        if len(data) < 50:
-            serialized_data = DataSerializer(d, many=False).data
-
-            temp = {
-                "Text": serialized_data["text"],
-                "metadata": serialized_data["metadata"],
-                "ID": d.id,
-            }
-            data.append(temp)
-
+    unlabeled_data = get_unlabeled_data(project_pk)[:50]
+    serialized_data = DataSerializer(unlabeled_data, many=True).data
+    data = [
+        {
+            "Text": d["text"],
+            "metadata": d["metadata"],
+            "ID": d["pk"],
+        }
+        for d in serialized_data
+    ]
     return Response({"data": data})
 
 
@@ -457,23 +454,19 @@ def search_data_unlabeled_table(request, project_pk):
         data: a filtered list of data information
     """
     unlabeled_data = get_unlabeled_data(project_pk)
-    data = []
     text = request.GET.get("text")
-    print(text)
-    for d in unlabeled_data:
-        if len(data) < 50:
-            serialized_data = DataSerializer(d, many=False).data
-
-            if text.lower() in serialized_data["text"].lower():
-                temp = {
-                    "data": serialized_data["text"],
-                    "metadata": serialized_data["metadata"],
-                    "id": d.id,
-                    "project": project_pk,
-                }
-                data.append(temp)
-
-    return Response({"data": data})
+    unlabeled_data = unlabeled_data.filter(text__icontains=text.lower())
+    serialized_data = DataSerializer(unlabeled_data, many=True).data
+    data = [
+        {
+            "data": d["text"],
+            "metadata": d["metadata"],
+            "id": d["pk"],
+            "project": project_pk,
+        }
+        for d in serialized_data
+    ]
+    return Response({"data": data[:50]})
 
 
 @api_view(["POST"])

--- a/frontend/src/styles/smart.scss
+++ b/frontend/src/styles/smart.scss
@@ -538,3 +538,19 @@ li.disabled {
     font-size: 14px;
     width: fit-content;
 }
+
+.skew-input {
+    border: 1px solid rgba(0,0,0,0.1);
+    background: #FFFFFF;
+    padding: 5px 7px;
+    font-size: inherit;
+    border-radius: 3px;
+    font-weight: 400;
+    outline-width: 0;
+    width: 100%;
+}
+
+.skew-search-button {
+    margin-bottom: 8px;
+    margin-top: 8px;
+}


### PR DESCRIPTION
This limits the number of unlabeled data to 50 on the skew table to prevent large projects from lagging out. It also adds a search input on top of the table to search through all of the unlabeled data for the project. A new API endpoint is used to handle searches.