### PR TITLE
replicating dev in prod

### DIFF
--- a/backend/docker/Dockerfile.prod
+++ b/backend/docker/Dockerfile.prod
@@ -1,11 +1,12 @@
-FROM python:3.5.7
+FROM python:3.8
 ENV PYTHONUNBUFFERED 1
-RUN apt-get update && apt-get install -y netcat-traditional mysql-client
+RUN apt-get update && apt-get install -y netcat-traditional
 WORKDIR /code
 ADD ./docker/requirements.txt /code/requirements.txt
+RUN pip install --upgrade pip
 RUN pip install  -r requirements.txt
 RUN pip install gunicorn
-ADD ./smart/ /code/
+ADD ./django/ /code/
 RUN mkdir -p /data/data_files /data/tf_idf /data/model_pickles /data/code_books
 EXPOSE 8000
 CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8000", "--timeout", "75", "--worker-class", "gevent", "config.wsgi"]

--- a/envs/prod/build-prod.sh
+++ b/envs/prod/build-prod.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+docker-compose down
+docker volume rm vol_smart_pgdata vol_smart_data
+docker volume create vol_smart_pgdata
+docker volume create vol_smart_data
+docker-compose build
+docker-compose run --rm smart_backend ./migrate.sh
+docker-compose run --rm smart_backend ./seed_smart.sh
+docker-compose up

--- a/envs/prod/docker-compose.yml
+++ b/envs/prod/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       dockerfile: docker/Dockerfile.prod
     image: rti/smart-backend-prod:R_0_0_1
     restart: always
+    ports:
+      - "80:8000"
     depends_on:
       - postgres
       - redis
@@ -28,13 +30,10 @@ services:
     extends:
       file: ../docker-common.yml
       service: smart_frontend
-    build:
-      context: ../../frontend/
-      dockerfile: Dockerfile.prod
-    image: rti/smart-frontend-prod:R_0_0_1
-    ports:
-      - "${EXTERNAL_FRONTEND_PORT:-8080}:8080"
-    command: nginx -c /code/nginx.conf -g "daemon off;"
+    build: ../../frontend/
+    image: rti/smart-frontend:R_0_0_1
+    command: node_modules/.bin/webpack --watch
+
 
 volumes:
   smart_pgdata:


### PR DESCRIPTION
This merge request adds a functional production docker-compose setup, with the frontend emulating the dev setup. Running the `build-prod.sh` bash script from `/envs/prod` should bring up a functional tool at port 80.

Lots more to say about the exploration required to come to this solution - let's chat about that soon.