### PR TITLE
hide progress bar, move adjudicate button

### DIFF
--- a/frontend/src/components/AnnotateCard/index.jsx
+++ b/frontend/src/components/AnnotateCard/index.jsx
@@ -14,7 +14,7 @@ export default function AnnotateCard({ card, labels, onSelectLabel, readonly = f
     return (
         <div className="cardface clearfix">
             <div className="cardface-datacard">
-                <CardData card={card} />
+                <CardData card={card} onSkip={onSkip} />
                 {suggestions && labels.length > 5 && (
                     <SuggestedLabels card={card} labels={labels} onSelectLabel={onSelectLabel} />
                 )}
@@ -33,12 +33,13 @@ function drawEditOptions(card, labels, onSelectLabel, onSkip, onDiscard) {
 
     return (
         <ButtonToolbar className="btn-toolbar">
+            {/* { onSkip != null && drawSkipButton(card, onSkip)} */}
+            <div className="toolbar-gap" />
             {labels.length > 5 ? (
                 drawLabelSelect(card, labelsOptions, onSelectLabel)
             ) : (
                 drawLabelButtons(card, labels, onSelectLabel)
             )}
-            { onSkip != null && drawSkipButton(card, onSkip) }
             { onDiscard != null && drawDiscardButton(card, onDiscard) }
         </ButtonToolbar>
     );
@@ -72,28 +73,6 @@ function drawLabelButtons(card, labels, onSelectLabel) {
                 {opt["name"]}
             </Button>
         ))
-    );
-}
-
-function drawSkipButton(card, onSkip) {
-    return (
-        <OverlayTrigger
-            placement="top"
-            overlay={
-                <Tooltip id="skip_tooltip">
-                    Clicking this button will send this
-                    document to an administrator for review
-                </Tooltip>
-            }
-        >
-            <Button
-                className="ajucate-button"
-                onClick={() => onSkip(card)}
-                variant="info"
-            >
-                Adjudicate
-            </Button>
-        </OverlayTrigger>
     );
 }
 

--- a/frontend/src/components/DataCard/CardData.jsx
+++ b/frontend/src/components/DataCard/CardData.jsx
@@ -1,15 +1,45 @@
 import React from "react";
+import {
+    Button,
+    Tooltip,
+    OverlayTrigger
+} from "react-bootstrap";
 
-export default function CardData({ card }) {
+export default function CardData({ card, onSkip }) {
     return (
         <div className="cardface-info">
-            <h2>Card {card.id + 1}</h2>
+            <div className="card-title">
+                <h2>Card {card.id + 1}</h2>
+                {drawSkipButton(card, onSkip)}
+            </div>
             <div className="card-data">
                 <h4>Text to Label</h4>
                 <p>{card.text["text"] || card.text["data"]}</p>
             </div>
             {extractMetadata(card)}
         </div>
+    );
+}
+
+function drawSkipButton(card, onSkip) {
+    return (
+        <OverlayTrigger
+            placement="top"
+            overlay={
+                <Tooltip id="skip_tooltip">
+                    Clicking this button will send this
+                    document to an administrator for review
+                </Tooltip>
+            }
+        >
+            <Button
+                className="ajucate-button"
+                onClick={() => onSkip(card)}
+                variant="info"
+            >
+                Adjudicate
+            </Button>
+        </OverlayTrigger>
     );
 }
 

--- a/frontend/src/components/SmartProgressBar/index.jsx
+++ b/frontend/src/components/SmartProgressBar/index.jsx
@@ -22,12 +22,13 @@ class SmartProgressBar extends React.Component {
         }
 
         return (
-            <ProgressBar>
-                <ProgressBar
-                    style={{ minWidth: 60 }}
-                    label={label}
-                    now={progress}/>
-            </ProgressBar>
+            // <ProgressBar>
+            //     <ProgressBar
+            //         style={{ minWidth: 60 }}
+            //         label={label}
+            //         now={progress}/>
+            // </ProgressBar>
+            <React.Fragment></React.Fragment>
         );
     }
 }

--- a/frontend/src/styles/smart.scss
+++ b/frontend/src/styles/smart.scss
@@ -141,6 +141,12 @@ main {
     }
 }
 
+.card-title {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+}
+
 .cardface-datacard {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
Hides the progress bar (I just commented it out and replace with a React Fragment so we have the code there in case we need it in the future.)

Moves the adjudicate button to the top right of the card.