### PR TITLE
add css to fix codebook modal

### DIFF
--- a/frontend/src/components/CodebookLabelMenu/index.jsx
+++ b/frontend/src/components/CodebookLabelMenu/index.jsx
@@ -52,7 +52,7 @@ class CodebookLabelMenu extends React.Component {
 
         if (CODEBOOK_URL != "") {
             codebook_module = (
-                <Modal show={this.state.codebook_open} onHide={this.toggleCodebook}>
+                <Modal style={{ opacity: 1 }} show={this.state.codebook_open} onHide={this.toggleCodebook}>
                     <Modal.Header closeButton>
                         <Modal.Title>Codebook</Modal.Title>
                     </Modal.Header>

--- a/frontend/src/styles/smart.scss
+++ b/frontend/src/styles/smart.scss
@@ -389,8 +389,34 @@ li.disabled {
     visibility: hidden;
 }
 
+.modal-open .modal {
+    display: flex !important;
+}
+
 .modal-content {
     z-index: auto;
+}
+
+.modal-backdrop.show {
+    opacity: 0.5 !important
+}
+
+.modal-dialog {
+    display: flex;
+    justify-content: center;
+    -webkit-transform: translate(0, 0%) !important;
+    -ms-transform: translate(0, 0%) !important;
+    -o-transform: translate(0, 0%) !important;
+    transform: translate(0, 0%) !important;
+}
+
+.mdoal-header {
+    display: flex;
+    align-items: center;
+}
+
+.modal-header .close {
+    margin: -1rem -1rem -1rem auto;
 }
 
 .overlay {


### PR DESCRIPTION
I noticed while attempting to make a modal for the adjudicate descriptions that our modal components aren't working. This adds css to fix them again. (The codebook menu modal on the annotate card page was not displaying.)