### PR TITLE
slugify folder names on project listing

### DIFF
--- a/backend/django/core/templates/projects/create/create_wizard_overview.html
+++ b/backend/django/core/templates/projects/create/create_wizard_overview.html
@@ -33,7 +33,8 @@
           </div>
           <div class="form-group">
             <label class="control-label" for="{{ wizard.form.umbrella_string.id_for_label }}">Folder</label>
-            <input class="form-control" id="{{ wizard.form.umbrella_string.id_for_label }}" maxlength="30" name="{{ wizard.form.umbrella_string.html_name }}" type="text" value="{{ form.umbrella_string.value|default_if_none:'' }}"/>
+            <input class="form-control" id="{{ wizard.form.umbrella_string.id_for_label }}" maxlength="30" name="{{ wizard.form.umbrella_string.html_name }}" pattern="^.*[a-zA-Z0-9]+.*$" type="text" value="{{ form.umbrella_string.value|default_if_none:'' }}"/>
+            <p style="margin-top: 4px;">Folder names must include at least one alphanumerical character.</p>
             <div class="error-messages">{{ wizard.form.umbrella_string.errors }}</div>
           </div>
           <div class="wizard_nav_bar">

--- a/backend/django/core/templates/projects/list.html
+++ b/backend/django/core/templates/projects/list.html
@@ -9,15 +9,15 @@
     <div class="list-group">
       {% for potential_umbrella_project in object_list %}
         {% if potential_umbrella_project.umbrella_string  %}
-        <div id="umbrella-{{potential_umbrella_project.umbrella_string}}" class="panel panel-default">
+        <div id="umbrella-{{potential_umbrella_project.umbrella_string|slugify}}" class="panel panel-default">
           <div class="panel-heading">
             <h5 class="panel-title">
-              <a data-toggle="collapse" href="#{{potential_umbrella_project.umbrella_string.split|join:"-"}}" class="accordion-toggle collapsed collapsed">
+              <a data-toggle="collapse" href="#{{potential_umbrella_project.umbrella_string|slugify}}" class="accordion-toggle collapsed collapsed">
                 {{ potential_umbrella_project.umbrella_string }}
               </a>
             </h5>
           </div>
-          <div id="{{potential_umbrella_project.umbrella_string.split|join:"-"}}" class="panel-collapse collapse">
+          <div id="{{potential_umbrella_project.umbrella_string|slugify}}" class="panel-collapse collapse">
             <div class="panel-body">
               <table class="table table-striped" style="border: 0;">
                 <tbody>

--- a/backend/django/core/templates/projects/update/umbrella.html
+++ b/backend/django/core/templates/projects/update/umbrella.html
@@ -17,7 +17,8 @@
            <h3>Instructions</h3>
            <p>Type the name of the folder in the input field you wish to categorize your project under. Projects with the same folder name will be automatically grouped together on the projects page.</p>
            {{ form.errors.as_ul }}
-           <input class="form-control" name="umbrella" placeholder="Folder Name" />
+           <input class="form-control" name="umbrella" placeholder="Folder Name" pattern="^.*[a-zA-Z0-9]+.*$" type="text" />
+           <p style="margin-top: 4px;">Folder names must include at least one alphanumerical character.</p>
            <br />
            <div class="form-group">
                <button class="btn btn-primary" type="submit">Submit</button>


### PR DESCRIPTION
Uses Django's built-in [slugify](https://docs.djangoproject.com/en/4.0/ref/templates/builtins/#slugify) util to slugify the folder names on the project listing. This solves the issue where folders with certain characters such as `:` or `^` were not opening properly.

**Note:** if two folders have the same characters minus the certain characters such as `:` or `^` one of them will not display.

For example:

- `folder2022` and `folder-2022` works ✅
- `folder2022` and `folder:2022` does not work ❌