### PR TITLE
Adds folder dropdown for project creation/update

### DIFF
--- a/backend/django/core/templates/projects/create/create_wizard_overview.html
+++ b/backend/django/core/templates/projects/create/create_wizard_overview.html
@@ -31,9 +31,15 @@
             <textarea class="form-control" id="{{ wizard.form.description.id_for_label }}" name="{{ wizard.form.description.html_name }}">{{ form.description.value|default_if_none:'' }}</textarea>
             <div class="error-messages">{{ wizard.form.description.errors }}</div>
           </div>
+          <datalist id="umbrella_choices">
+            {% for item in umbrella_choices %}
+              <option value="{{ item }}">
+            {% endfor %}
+          </datalist>
           <div class="form-group">
             <label class="control-label" for="{{ wizard.form.umbrella_string.id_for_label }}">Folder</label>
-            <input class="form-control" id="{{ wizard.form.umbrella_string.id_for_label }}" maxlength="30" name="{{ wizard.form.umbrella_string.html_name }}" pattern="^.*[a-zA-Z0-9]+.*$" type="text" value="{{ form.umbrella_string.value|default_if_none:'' }}"/>
+            <input class="form-control" placeholder="Folder Name" id="{{ wizard.form.umbrella_string.id_for_label }}" maxlength="30" name="{{ wizard.form.umbrella_string.html_name }}" pattern="^.*[a-zA-Z0-9]+.*$" type="text" value="{{ form.umbrella_string.value|default_if_none:'' }}" list = "umbrella_choices" autocomplete="off"/>
+            <p style="margin-top: 4px;">Type a new folder name or select an already created folder</p>
             <p style="margin-top: 4px;">Folder names must include at least one alphanumerical character.</p>
             <div class="error-messages">{{ wizard.form.umbrella_string.errors }}</div>
           </div>

--- a/backend/django/core/templates/projects/update/umbrella.html
+++ b/backend/django/core/templates/projects/update/umbrella.html
@@ -10,19 +10,25 @@
        <div class="cardface">
          {{ form.media.css }}
          <form action="." method="post" enctype="multipart/form-data">
-           {% csrf_token %}
-           <h1>Add Project To Folder</h1>
-           <h3>Description</h3>
-           <p>To help organize your projects, you can assign projects to folders displayed on the project page.</p>
-           <h3>Instructions</h3>
-           <p>Type the name of the folder in the input field you wish to categorize your project under. Projects with the same folder name will be automatically grouped together on the projects page.</p>
-           {{ form.errors.as_ul }}
-           <input class="form-control" name="umbrella" placeholder="Folder Name" pattern="^.*[a-zA-Z0-9]+.*$" type="text" />
-           <p style="margin-top: 4px;">Folder names must include at least one alphanumerical character.</p>
-           <br />
-           <div class="form-group">
-               <button class="btn btn-primary" type="submit">Submit</button>
-           </div>
+            {% csrf_token %}
+            <h1>Add Project To Folder</h1>
+            <h3>Description</h3>
+            <p>To help organize your projects, you can assign projects to folders displayed on the project page.</p>
+            <h3>Instructions</h3>
+            <p>Type the name of the folder in the input field you wish to categorize your project under. Projects with the same folder name will be automatically grouped together on the projects page.</p>
+            {{ form.errors.as_ul }}
+            <datalist id="umbrella_choices">
+              {% for item in umbrella_choices %}
+                <option value="{{ item }}">
+              {% endfor %}
+            </datalist>
+            <input class="form-control" name="umbrella" placeholder="Folder Name" pattern="^.*[a-zA-Z0-9]+.*$" list="umbrella_choices" autocomplete="off"/>
+            <p style="margin-top: 4px;">Type a new folder name or select an already created folder</p>
+            <p style="margin-top: 4px;">Folder names must include at least one alphanumerical character.</p>
+            <br />
+            <div class="form-group">
+                <button class="btn btn-primary" type="submit">Submit</button>
+            </div>
          </form>
        </div>
      </div>

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -298,7 +298,9 @@ def update_label_embeddings(project):
         for embedding, label_embedding in zip(embeddings, project_labels_embeddings):
             label_embedding.embedding = embedding.tolist()
 
-        LabelEmbeddings.objects.bulk_update(project_labels_embeddings, ["embedding"], batch_size=8000)
+        LabelEmbeddings.objects.bulk_update(
+            project_labels_embeddings, ["embedding"], batch_size=8000
+        )
 
 
 def add_data(project, df):


### PR DESCRIPTION
Adds the ability to select folders when adding a new project or updating a project's folder.
Folder selection is based on current user's access to other projects and their folders.

Thoughts:
- Changing Umbrella_string to be separate Django Model which Project FKs to. I think this would make it easier to create empty folders and a basic create folder button on the project list page.
- Making the "Other Projects"  folder more obvious as the default folder.
