### PR TITLE
add coders to permission status for comparisons

### DIFF
--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -298,7 +298,9 @@ def update_label_embeddings(project):
         for embedding, label_embedding in zip(embeddings, project_labels_embeddings):
             label_embedding.embedding = embedding.tolist()
 
-        LabelEmbeddings.objects.bulk_update(project_labels_embeddings, ["embedding"], batch_size=8000)
+        LabelEmbeddings.objects.bulk_update(
+            project_labels_embeddings, ["embedding"], batch_size=8000
+        )
 
 
 def add_data(project, df):

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -499,7 +499,7 @@ def embeddings_calculations(request):
 
 
 @api_view(["GET"])
-@permission_classes((IsAdminOrCreator,))
+@permission_classes((IsCoder,))
 def embeddings_comparison(request, project_pk):
     """This finds the highest scoring labels when comparing cosine similarity scores of
     their embeddingsfor a given input string.


### PR DESCRIPTION
We accidentally had the `api/comparisons` endpoint to only allow project creators or admins. Should be creators, admins, and **coders**.