### PR TITLE
fix skip dropdown

### DIFF
--- a/frontend/src/components/AdminTable/index.jsx
+++ b/frontend/src/components/AdminTable/index.jsx
@@ -100,7 +100,10 @@ class AdminTable extends React.Component {
                         min-width: 200px;\
                         width: fit-content;\
                     }\
-                "
+                    .rt-td {\
+                        overflow-y: auto !important;\
+                    }\
+                " 
                     }
                 </style>
             </div>

--- a/frontend/src/styles/smart.scss
+++ b/frontend/src/styles/smart.scss
@@ -245,6 +245,11 @@ main {
         text-overflow: ellipsis;
     }
 
+    .react-dropdown-select-item {
+        max-width: 400px;
+        white-space: pre-wrap;
+    }
+
     .annotate-select .react-dropdown-select-item:hover {
         text-decoration: underline;
     }


### PR DESCRIPTION
This took quite a while to play around with... it's a weird case where the the `react-select` dropdown uses absolute positioning to display the dropdown of labels. However, the `react-table` table prevents any overflow from displaying.

I tried a lot of different solutions (changing positioning, increasing z-index, etc.) but nothing was completely fixing it.

The best solution was adding an overflow scroll vertically to the entire card within the table. This allows you to scroll down and see the entire dropdown of labels. However, this only lets you scroll if you are within the card (scrolling on the outside of the card - such as in the green space around the content, won't do anything.)

The other option could be to just put a lot of padding at the bottom of the card in the skipped page, but that would maybe look weird having a ton of whitespace when you aren't looking through the dropdown?

I may also be missing a simple solution, but not sure. I spent a good amount of time until I settled on this solution, which gets the job done.