### PR TITLE
Forbid duplicate data with labels from being ingested

### DIFF
--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -499,10 +499,14 @@ class DataUpdateWizardForm(forms.Form):
 
             # Throw error containing rows which are going to overwritten
             if not overwrite_data.empty:
-                error_str = "The following rows are already in the database and the labels will be overwritten:\n\n"
-                df_str = overwrite_data.to_csv(index=False) + "\n"
+                error_str = "The following uploaded text + metadata combinations are already in the database and the uploaded labels will not be reflected in the database:\n\n"
+                df_str = overwrite_data.head(10).to_csv(index=False)
+                size = overwrite_data.shape[0]
+                remaining_str = (
+                    f"----{size-10} rows remaining----\n\n" if size > 10 else "\n\n"
+                )
                 hint_str = "Please delete the labels or remove the rows before uploading the data"
-                raise ValidationError(error_str + df_str + hint_str)
+                raise ValidationError(error_str + df_str + remaining_str + hint_str)
 
 
 class CodeBookWizardForm(forms.Form):

--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -500,7 +500,7 @@ class DataUpdateWizardForm(forms.Form):
             # Throw error containing rows which are going to overwritten
             if not overwrite_data.empty:
                 error_str = "The following rows are already in the database and the labels will be overwritten:\n\n"
-                df_str = overwrite_data.to_csv(header=False, index=False) + "\n"
+                df_str = overwrite_data.to_csv(index=False) + "\n"
                 hint_str = "Please delete the labels or remove the rows before uploading the data"
                 raise ValidationError(error_str + df_str + hint_str)
 

--- a/backend/django/core/templates/projects/create/create_wizard_data.html
+++ b/backend/django/core/templates/projects/create/create_wizard_data.html
@@ -35,6 +35,7 @@
                         column would contain the tweets.</p>
                     <p>The (optional) <code>Label</code> column should contain any pre-exisiting labels for the corresponding text. If none of your data contains existing labels, then this column can be left blank. Extending our sentiment analysis example, if a
                         lead coder has already annotated some tweets as positive, negative, or neutral, this column would contain those labeled records.</p>
+                    <p>The labels in the database uploaded now or annotated using SMART are given priority. Any duplicate text uploaded later with new labels will not update labels already in the database</p>
                     <p><b>All additional columns in the data file or table will be saved as metadata and the values will be displayed along with the text for labeling. These fields can be empty for some or all data. Currently SMART does not support using metadata values in its models.</b></p>
 
 

--- a/backend/django/core/templates/projects/update/data.html
+++ b/backend/django/core/templates/projects/update/data.html
@@ -18,6 +18,7 @@
           <ul class="list-group">
             <li class="list-group-item">The file needs to have either a <code>.csv</code> or <code>.tsv</code> file extension.</li>
             <li class="list-group-item">The file requires the data to be formatted with the same columns as the original uploaded dataset.</li>
+            <li class="list-group-item">The file must not contain duplicate data with nonempty labels</li>
             <li class="list-group-item">The largest file size supported is 500MBs.</li>
           </ul>
           <p>The (optional) <code>ID</code> column should contain a <b>unique</b> identifier for your data. The identifiers should be no more than 128 characters.</p>

--- a/backend/django/core/templates/projects/update/data.html
+++ b/backend/django/core/templates/projects/update/data.html
@@ -33,7 +33,7 @@
           <div class="form-group">
             <label class="control-label" for="{{ form.data.id_for_label }}">{{ form.data.label }}</label>
             <input class="form-control" id="{{ form.data.id_for_label }}" maxlength="30" name="{{ form.data.html_name }}" type="file" placeholder="{{ form.data.label }}" />
-            <div class="error-messages">{{ form.data.errors }}</div>
+            <div class="error-messages">{{ form.data.errors|linebreaks }}</div>
           </div>
           {% else %}
           <div>

--- a/backend/django/core/templates/projects/update/data.html
+++ b/backend/django/core/templates/projects/update/data.html
@@ -24,6 +24,7 @@
           <p>The (optional) <code>ID</code> column should contain a <b>unique</b> identifier for your data. The identifiers should be no more than 128 characters.</p>
           <p>The <code>Text</code> column should contain the text you wish users to label. For example, if you are building a sentiment analysis model to predict whether a tweet is positive, negative, or neutral, the <code>Text</code> column would contain the tweets.</p>
           <p>The (optional) <code>Label</code> column should contain any pre-exisiting labels for the corresponding text. If none of your data contains existing labels, then this column can be left blank. Extending our sentiment analysis example, if a lead coder has already annotated some tweets as positive, negative, or neutral, this column would contain those labeled records.</p>
+          <p>The labels in the database uploaded now or annotated using SMART are given priority. Any duplicate text uploaded later with new labels will not update labels already in the database</p>
           <p><i>Data Upload Notes:</i></p>
           <ul class="list-group">
             <li class="list-group-item">SMART restricts your project to having two million unique records.</li>

--- a/backend/django/core/views/frontend.py
+++ b/backend/django/core/views/frontend.py
@@ -449,6 +449,8 @@ class ProjectUpdateData(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     def get_form_kwargs(self):
         form_kwargs = super(ProjectUpdateData, self).get_form_kwargs()
 
+        form_kwargs["project"] = Project.objects.get(pk=self.kwargs["pk"])
+
         form_kwargs["labels"] = list(
             Label.objects.filter(project=form_kwargs["instance"]).values_list(
                 "name", flat=True


### PR DESCRIPTION
This throws a form error is duplicate data with old labels in ingested through the update data pipeline. Does not affect project creation data upload.

Error shows which rows in the uploaded data contains this problem