### PR TITLE
add option to skip queue without adjudicating (for later)

### DIFF
--- a/backend/django/core/urls/api.py
+++ b/backend/django/core/urls/api.py
@@ -34,6 +34,7 @@ annotate_patterns = [
     re_path(
         r"^modify_label_to_skip/(?P<data_pk>\d+)/$", api_annotate.modify_label_to_skip
     ),
+    re_path(r"^unassign_data/(?P<data_pk>\d+)/$", api_annotate.unassign_data),
     re_path(r"^skip_data/(?P<data_pk>\d+)/$", api_annotate.skip_data),
     re_path(
         r"^enter_coding_page/(?P<project_pk>\d+)/$", api_annotate.enter_coding_page

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -123,6 +123,28 @@ def label_distribution_inverted(request, project_pk):
 
 @api_view(["POST"])
 @permission_classes((IsCoder,))
+def unassign_data(request, data_pk):
+    """Take a datum that is in the assigneddata queue for that user and remove it from
+    the assignedData queue.
+
+    Args:
+        request: The POST request
+        data_pk: Primary key of the data
+    Returns:
+        {}
+    """
+    data = Data.objects.get(pk=data_pk)
+    profile = request.user.profile
+    response = {}
+
+    assignment = AssignedData.objects.get(data=data, profile=profile)
+    assignment.delete()
+
+    return Response(response)
+
+
+@api_view(["POST"])
+@permission_classes((IsCoder,))
 def skip_data(request, data_pk):
     """Take a datum that is in the assigneddata queue for that user and place it in the
     admin queue. Remove it from the assignedData queue.
@@ -159,9 +181,8 @@ def skip_data(request, data_pk):
             process_irr_label(data, None)
     else:
         # the data is not IRR so treat it as normal
-        if request.data["addToAdminQueue"]:
-            move_skipped_to_admin_queue(data, profile, project)
-            createUnresolvedAdjudicateMessage(project, data, request.data["message"])
+        move_skipped_to_admin_queue(data, profile, project)
+        createUnresolvedAdjudicateMessage(project, data, request.data["message"])
 
     # for all data, check if we need to refill queue
     check_and_trigger_model(data, profile)

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -140,9 +140,6 @@ def unassign_data(request, data_pk):
     assignment = AssignedData.objects.get(data=data, profile=profile)
     assignment.delete()
 
-    # for all data, check if we need to refill queue
-    check_and_trigger_model(data, profile)
-
     return Response(response)
 
 

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -159,8 +159,9 @@ def skip_data(request, data_pk):
             process_irr_label(data, None)
     else:
         # the data is not IRR so treat it as normal
-        move_skipped_to_admin_queue(data, profile, project)
-        createUnresolvedAdjudicateMessage(project, data, request.data["message"])
+        if request.data["addToAdminQueue"]:
+            move_skipped_to_admin_queue(data, profile, project)
+            createUnresolvedAdjudicateMessage(project, data, request.data["message"])
 
     # for all data, check if we need to refill queue
     check_and_trigger_model(data, profile)

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -140,6 +140,9 @@ def unassign_data(request, data_pk):
     assignment = AssignedData.objects.get(data=data, profile=profile)
     assignment.delete()
 
+    # for all data, check if we need to refill queue
+    check_and_trigger_model(data, profile)
+
     return Response(response)
 
 

--- a/frontend/src/actions/card.js
+++ b/frontend/src/actions/card.js
@@ -88,11 +88,37 @@ export const annotateCard = (card, labelID, num_cards_left, projectID, is_admin)
     };
 };
 
+//unassign a card
+export const unassignCard = (card, num_cards_left, is_admin, projectID) => {
+    let apiURL = `/api/unassign_data/${card.text.pk}/`;
+    return dispatch => {
+        return fetch(apiURL, postConfig())
+            .then(response => {
+                if (response.ok) {
+                    return response.json();
+                } else {
+                    const error = new Error(response.statusText);
+                    error.response = response;
+                    throw error;
+                }
+            })
+            .then(response => {
+                if ('error' in response) {
+                    dispatch(clearDeck());
+                    return dispatch(setMessage(response.error));
+                } else {
+                    dispatch(popCard());
+                    if (num_cards_left <= 1) dispatch(fetchCards(projectID));
+                }
+            });
+    };
+};
+
 //skip a card and put it in the admin table
-export const passCard = (card, num_cards_left, is_admin, projectID, addToAdminQueue, message) => {
+export const passCard = (card, num_cards_left, is_admin, projectID, message) => {
     let apiURL = `/api/skip_data/${card.text.pk}/`;
     return dispatch => {
-        return fetch(apiURL, postConfig({ addToAdminQueue, message }))
+        return fetch(apiURL, postConfig({ message }))
             .then(response => {
                 if (response.ok) {
                     return response.json();

--- a/frontend/src/actions/card.js
+++ b/frontend/src/actions/card.js
@@ -89,10 +89,10 @@ export const annotateCard = (card, labelID, num_cards_left, projectID, is_admin)
 };
 
 //skip a card and put it in the admin table
-export const passCard = (card, num_cards_left, is_admin, projectID, message) => {
+export const passCard = (card, num_cards_left, is_admin, projectID, addToAdminQueue, message) => {
     let apiURL = `/api/skip_data/${card.text.pk}/`;
     return dispatch => {
-        return fetch(apiURL, postConfig({ message: message }))
+        return fetch(apiURL, postConfig({ addToAdminQueue, message }))
             .then(response => {
                 if (response.ok) {
                     return response.json();

--- a/frontend/src/components/AnnotateCard/index.jsx
+++ b/frontend/src/components/AnnotateCard/index.jsx
@@ -10,11 +10,11 @@ import Select from "react-dropdown-select";
 import CardData from '../DataCard/CardData';
 import SuggestedLabels from '../DataCard/SuggestedLabels';
 
-export default function AnnotateCard({ card, labels, onSelectLabel, readonly = false, onSkip = null, onDiscard = null, showAdjudicate = true, suggestions = true }) {
+export default function AnnotateCard({ card, labels, onSelectLabel, readonly = false, onSkip = null, onDiscard = null, onUnassign = null, showAdjudicate = true, suggestions = true }) {
     return (
         <div className="cardface clearfix">
             <div className="cardface-datacard">
-                <CardData card={card} onSkip={onSkip} showAdjudicate={showAdjudicate} />
+                <CardData card={card} onSkip={onSkip} onUnassign={onUnassign} showAdjudicate={showAdjudicate} />
                 {suggestions && labels.length > 5 && (
                     <SuggestedLabels card={card} labels={labels} onSelectLabel={onSelectLabel} />
                 )}

--- a/frontend/src/components/DataCard/CardData.jsx
+++ b/frontend/src/components/DataCard/CardData.jsx
@@ -11,6 +11,7 @@ export default function CardData({ card, onSkip, showAdjudicate = true }) {
         <div className="cardface-info">
             {showAdjudicate && (
                 <div className="card-title" style={{ display: "flex", justifyContent: 'flex-end' }}>
+                    {drawSkipQueueButton(card, onSkip)}
                     {drawSkipButton(card, onSkip)}
                 </div>
             )}
@@ -29,7 +30,7 @@ function drawSkipButton(card, onSkip) {
 
     const handleSkip = (event) => {
         event.preventDefault();
-        onSkip(card, message);
+        onSkip(card, true, message);
     };
 
     return (
@@ -65,6 +66,31 @@ function drawSkipButton(card, onSkip) {
                     </form>
                 </Modal.Body>
             </Modal>
+        </Fragment>
+    );
+}
+
+function drawSkipQueueButton(card, onSkip) {
+    return (
+        <Fragment>
+            <OverlayTrigger
+                placement="top"
+                overlay={
+                    <Tooltip id="skip_tooltip">
+                        Clicking this button will skip this card for later.
+                    </Tooltip>
+                }
+            >
+                
+                <Button
+                    className="ajucate-button"
+                    onClick={() => onSkip(card, false)}
+                    style={{ marginRight: "0.25rem" }}
+                    variant="info"
+                >
+                    Skip
+                </Button>
+            </OverlayTrigger>
         </Fragment>
     );
 }

--- a/frontend/src/components/DataCard/CardData.jsx
+++ b/frontend/src/components/DataCard/CardData.jsx
@@ -6,12 +6,12 @@ import {
     OverlayTrigger
 } from "react-bootstrap";
 
-export default function CardData({ card, onSkip, showAdjudicate = true }) {
+export default function CardData({ card, onSkip, onUnassign, showAdjudicate = true }) {
     return (
         <div className="cardface-info">
             {showAdjudicate && (
                 <div className="card-title" style={{ display: "flex", justifyContent: 'flex-end' }}>
-                    {drawSkipQueueButton(card, onSkip)}
+                    {drawSkipQueueButton(card, onUnassign)}
                     {drawSkipButton(card, onSkip)}
                 </div>
             )}
@@ -30,7 +30,7 @@ function drawSkipButton(card, onSkip) {
 
     const handleSkip = (event) => {
         event.preventDefault();
-        onSkip(card, true, message);
+        onSkip(card, message);
     };
 
     return (
@@ -70,7 +70,9 @@ function drawSkipButton(card, onSkip) {
     );
 }
 
-function drawSkipQueueButton(card, onSkip) {
+function drawSkipQueueButton(card, onUnassign) {
+    if (!onUnassign) return null;
+
     return (
         <Fragment>
             <OverlayTrigger
@@ -84,7 +86,7 @@ function drawSkipQueueButton(card, onSkip) {
                 
                 <Button
                     className="ajucate-button"
-                    onClick={() => onSkip(card, false)}
+                    onClick={() => onUnassign(card)}
                     style={{ marginRight: "0.25rem" }}
                     variant="info"
                 >

--- a/frontend/src/components/DataCard/datacard.spec.js
+++ b/frontend/src/components/DataCard/datacard.spec.js
@@ -15,7 +15,8 @@ describe('<DataCard />', () => {
                 message = {message}
                 fetchCards = {fn}
                 annotateCard = {fn}
-                passCard = {fn}
+                passCard={fn}
+                unassignCard={fn}
               />
             );
         });

--- a/frontend/src/components/DataCard/index.jsx
+++ b/frontend/src/components/DataCard/index.jsx
@@ -36,7 +36,7 @@ class DataCard extends React.Component {
                                 cards.length,
                                 ADMIN
                             )}
-                        onSkip={(card, message = null) => passCard(card, cards.length, ADMIN, message)}
+                        onSkip={(card, addToAdminQueue, message = null) => passCard(card, cards.length, ADMIN, addToAdminQueue, message)}
                     />
                 </div>
             );

--- a/frontend/src/components/DataCard/index.jsx
+++ b/frontend/src/components/DataCard/index.jsx
@@ -20,7 +20,7 @@ class DataCard extends React.Component {
     render() {
         let card;
 
-        const { labels, message, cards, passCard, annotateCard } = this.props;
+        const { labels, message, cards, passCard, annotateCard, unassignCard } = this.props;
 
         if (!(cards === undefined) && cards.length > 0) {
             //just get the labels from the cards
@@ -36,7 +36,8 @@ class DataCard extends React.Component {
                                 cards.length,
                                 ADMIN
                             )}
-                        onSkip={(card, addToAdminQueue, message = null) => passCard(card, cards.length, ADMIN, addToAdminQueue, message)}
+                        onSkip={(card, message = null) => passCard(card, cards.length, ADMIN, message)}
+                        onUnassign={(card) => unassignCard(card, card.length, ADMIN)}
                     />
                 </div>
             );
@@ -57,7 +58,8 @@ DataCard.propTypes = {
     fetchCards: PropTypes.func.isRequired,
     annotateCard: PropTypes.func.isRequired,
     passCard: PropTypes.func.isRequired,
-    labels: PropTypes.arrayOf(PropTypes.object)
+    labels: PropTypes.arrayOf(PropTypes.object),
+    unassignCard: PropTypes.func.isRequired
 };
 
 export default DataCard;

--- a/frontend/src/components/Smart/index.jsx
+++ b/frontend/src/components/Smart/index.jsx
@@ -56,7 +56,7 @@ class Smart extends React.Component {
                         <Badge className="tab-badge">
                             {admin_counts["IRR"]}
                         </Badge>
-                        | Skipped
+                        | Requires Adjudication
                         <Badge className="tab-badge">
                             {admin_counts["SKIP"]}
                         </Badge>
@@ -65,7 +65,7 @@ class Smart extends React.Component {
             } else {
                 badges = (
                     <div>
-                        Skipped
+                        Requires Adjudication
                         <Badge className="tab-badge">
                             {admin_counts["SKIP"]}
                         </Badge>
@@ -85,7 +85,7 @@ class Smart extends React.Component {
             );
         } else {
             adminTabAdminTable = (
-                <Tab eventKey={4} transition={false} title="Skipped Cards" className="full card">
+                <Tab eventKey={4} transition={false} title="Requires Adjudication" className="full card">
                     <div className="cardContent">
                         <h2>Another admin is currently using this page. Please check back later.</h2>
                     </div>

--- a/frontend/src/containers/card_container.jsx
+++ b/frontend/src/containers/card_container.jsx
@@ -24,8 +24,8 @@ const mapDispatchToProps = (dispatch) => {
         annotateCard: (dataID, labelID, num_cards_left, is_admin) => {
             dispatch(annotateCard(dataID, labelID, num_cards_left, PROJECT_ID, is_admin));
         },
-        passCard: (dataID, num_cards_left, is_admin, message) => {
-            dispatch(passCard(dataID, num_cards_left, is_admin, PROJECT_ID, message));
+        passCard: (dataID, num_cards_left, is_admin, addToAdminQueue, message) => {
+            dispatch(passCard(dataID, num_cards_left, is_admin, PROJECT_ID, addToAdminQueue, message));
         }
     };
 };

--- a/frontend/src/containers/card_container.jsx
+++ b/frontend/src/containers/card_container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { fetchCards, annotateCard, passCard } from '../actions/card';
+import { fetchCards, annotateCard, passCard, unassignCard } from '../actions/card';
 import DataCard from '../components/DataCard';
 
 const PROJECT_ID = window.PROJECT_ID;
@@ -24,8 +24,11 @@ const mapDispatchToProps = (dispatch) => {
         annotateCard: (dataID, labelID, num_cards_left, is_admin) => {
             dispatch(annotateCard(dataID, labelID, num_cards_left, PROJECT_ID, is_admin));
         },
-        passCard: (dataID, num_cards_left, is_admin, addToAdminQueue, message) => {
-            dispatch(passCard(dataID, num_cards_left, is_admin, PROJECT_ID, addToAdminQueue, message));
+        passCard: (dataID, num_cards_left, is_admin, message) => {
+            dispatch(passCard(dataID, num_cards_left, is_admin, PROJECT_ID, message));
+        },
+        unassignCard: (dataId, num_cards_left, is_admin) => {
+            dispatch(unassignCard(dataId, num_cards_left, is_admin, PROJECT_ID));
         }
     };
 };


### PR DESCRIPTION
Adds a button to just "Skip" a card. This does almost everything the same as our current "Adjudicate Button" except for adding that card to the Admin queue.

Renames the "Skipped" tab to "Requires Adjudication"