### PR TITLE
Leave coding page patch

### DIFF
--- a/backend/django/core/apps.py
+++ b/backend/django/core/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class CoreConfig(AppConfig):
     name = "core"
+
+    def ready(self):
+        import core.signals  # noqa: F401

--- a/backend/django/core/signals.py
+++ b/backend/django/core/signals.py
@@ -1,0 +1,17 @@
+from allauth.account.signals import user_logged_out
+from django.dispatch import receiver
+
+from core.models import Project
+from core.utils.utils_annotate import leave_coding_page
+
+
+@receiver(user_logged_out)
+def on_user_logout(sender, **kwargs):
+    profile = kwargs["user"].pk
+    qs = Project.objects.filter(creator=profile) | Project.objects.filter(
+        projectpermissions__profile=profile
+    )
+    profile_projects = qs.distinct()
+    for project in profile_projects:
+        print("Removing user", profile, "from coding page for project", project)
+        leave_coding_page(profile, project)

--- a/backend/django/core/signals.py
+++ b/backend/django/core/signals.py
@@ -1,17 +1,17 @@
 from allauth.account.signals import user_logged_out
+from django.db.models import Q
 from django.dispatch import receiver
 
-from core.models import Project
+from core.models import Profile, Project
 from core.utils.utils_annotate import leave_coding_page
 
 
 @receiver(user_logged_out)
 def on_user_logout(sender, **kwargs):
-    profile = kwargs["user"].pk
-    qs = Project.objects.filter(creator=profile) | Project.objects.filter(
-        projectpermissions__profile=profile
-    )
-    profile_projects = qs.distinct()
+    profile = Profile.objects.get(pk=kwargs["user"].pk)
+    profile_projects = Project.objects.filter(
+        Q(creator=profile) | Q(projectpermissions__profile=profile)
+    ).distinct()
+
     for project in profile_projects:
-        print("Removing user", profile, "from coding page for project", project)
         leave_coding_page(profile, project)

--- a/backend/django/core/templates/smart/smart.html
+++ b/backend/django/core/templates/smart/smart.html
@@ -15,13 +15,6 @@ window.PROJECT_ID = {{ pk }};
   window.CODEBOOK_URL = "{% static project.codebook_file %}"
 {% endif %}
 window.ADMIN = {{admin}};
-window.onbeforeunload = function (e) {
-  $.ajax({
-    type: 'GET',
-    async: false,
-    url: '/api/leave_coding_page/'+{{ pk }}+'/',
-  });
-};
 window.onload = function (e) {
   $.ajax({
     type: 'GET',

--- a/backend/django/core/urls/api.py
+++ b/backend/django/core/urls/api.py
@@ -39,9 +39,6 @@ annotate_patterns = [
         r"^enter_coding_page/(?P<project_pk>\d+)/$", api_annotate.enter_coding_page
     ),
     re_path(
-        r"^leave_coding_page/(?P<project_pk>\d+)/$", api_annotate.leave_coding_page
-    ),
-    re_path(
         r"^data_unlabeled_table/(?P<project_pk>\d+)/$",
         api_annotate.data_unlabeled_table,
     ),

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -668,6 +668,7 @@ def get_projects(self, order_by_folders):
     projects = qs.distinct()
     if order_by_folders:
         projects = projects.order_by(self.ordering).reverse()
+
     return projects
 
 

--- a/backend/django/core/utils/utils_annotate.py
+++ b/backend/django/core/utils/utils_annotate.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 
 from core.models import (
     AdjudicateDescription,
+    AdminProgress,
     AssignedData,
     Data,
     DataLabel,
@@ -21,6 +22,19 @@ from core.utils.utils_redis import (
     redis_serialize_queue,
     redis_serialize_set,
 )
+
+
+def leave_coding_page(profile, project):
+    """unnasign data and remove any admin locks for a specific user and project."""
+    assigned_data = AssignedData.objects.filter(profile=profile)
+
+    for assignment in assigned_data:
+        unassign_datum(assignment.data, profile)
+
+    if project_extras.proj_permission_level(project, profile) > 1:
+        if AdminProgress.objects.filter(project=project, profile=profile).count() > 0:
+            prog = AdminProgress.objects.get(project=project, profile=profile)
+            prog.delete()
 
 
 def assign_datum(profile, project, type="normal"):

--- a/backend/django/core/views/api_admin.py
+++ b/backend/django/core/views/api_admin.py
@@ -19,6 +19,7 @@ from core.models import (
 )
 from core.permissions import IsAdminOrCreator, IsCoder
 from core.utils.util import irr_heatmap_data, perc_agreement_table_data, project_status
+from core.utils.utils_annotate import leave_coding_page
 from core.utils.utils_model import cohens_kappa, fleiss_kappa
 
 
@@ -323,6 +324,7 @@ def get_project_status(request, project_pk):
     """
 
     project = Project.objects.get(pk=project_pk)
+    leave_coding_page(request.user.profile, project)
     project_details = project_status(project)
 
     return Response(project_details)

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -36,9 +36,9 @@ from core.utils.utils_annotate import (
     get_embeddings,
     get_unlabeled_data,
     label_data,
+    leave_coding_page,
     move_skipped_to_admin_queue,
     process_irr_label,
-    unassign_datum,
 )
 from core.utils.utils_model import check_and_trigger_model
 from core.utils.utils_redis import redis_serialize_data, redis_serialize_set
@@ -397,37 +397,26 @@ def enter_coding_page(request, project_pk):
     """
     profile = request.user.profile
     project = Project.objects.get(pk=project_pk)
+    print("Profile", profile, "is entering coding page for", project)
     # check that no other admin is using it. If they are not, give this admin permission
     if project_extras.proj_permission_level(project, profile) > 1:
         if AdminProgress.objects.filter(project=project).count() == 0:
             AdminProgress.objects.create(
                 project=project, profile=profile, timestamp=timezone.now()
             )
-    return Response({})
 
+    # NEW leave the coding page for all other projects so they're only in one
+    # project at a time
+    qs = Project.objects.filter(creator=profile) | Project.objects.filter(
+        projectpermissions__profile=profile
+    )
+    projects = qs.distinct()
 
-@api_view(["GET"])
-def leave_coding_page(request, project_pk):
-    """API request meant to be sent when a user navigates away from the coding page
-    captured with 'beforeunload' event.  This should use assign_data to remove any data
-    currently assigned to the user and re-add it to redis.
+    profile_projects = [p for p in projects if p != project]
+    for project in profile_projects:
+        print("Profile", profile, "is leaving coding page for other project", project)
+        leave_coding_page(profile, projects)
 
-    Args:
-        request: The GET request
-    Returns:
-        {}
-    """
-    profile = request.user.profile
-    project = Project.objects.get(pk=project_pk)
-    assigned_data = AssignedData.objects.filter(profile=profile)
-
-    for assignment in assigned_data:
-        unassign_datum(assignment.data, profile)
-
-    if project_extras.proj_permission_level(project, profile) > 1:
-        if AdminProgress.objects.filter(project=project, profile=profile).count() > 0:
-            prog = AdminProgress.objects.get(project=project, profile=profile)
-            prog.delete()
     return Response({})
 
 

--- a/backend/django/core/views/frontend.py
+++ b/backend/django/core/views/frontend.py
@@ -40,7 +40,7 @@ from core.utils.util import (
     update_label_embeddings,
     upload_data,
 )
-from core.utils.utils_annotate import batch_unassign
+from core.utils.utils_annotate import batch_unassign, leave_coding_page
 from core.utils.utils_external_db import delete_external_db_file, save_external_db_file
 from core.utils.utils_queue import add_queue, find_queue_length
 
@@ -109,6 +109,7 @@ class ProjectList(LoginRequiredMixin, ListView):
         projects = get_projects(self, True)
         for project in projects:
             project_details = project_status(project)
+            leave_coding_page(self.request.user.profile, project)
             project.project_details = project_details
 
         return projects

--- a/frontend/src/components/DataCard/index.jsx
+++ b/frontend/src/components/DataCard/index.jsx
@@ -43,7 +43,7 @@ class DataCard extends React.Component {
         } else {
             let blankDeckMessage = message
                 ? message
-                : "No more data to label at this time. Please check back later";
+                : "No more data to label at this time. There may be no data left to label, or all data may be assigned to other coders who are logged into the project. Please check back later.";
             card = <Card body>{blankDeckMessage}</Card>;
         }
 

--- a/frontend/src/components/Smart/index.jsx
+++ b/frontend/src/components/Smart/index.jsx
@@ -35,7 +35,7 @@ class Smart extends React.Component {
             adminTabSkew = (
                 <Tab eventKey={3} transition={false} title="Fix Skew" className="full card">
                     <div className="cardContent">
-                        <h2>Another admin is currently using this page. This page will become available when the admin returns to the project list page, changes projects, or logs out.</h2>
+                        <h2>Another admin is currently using this page. This page will become available when the admin returns to the project list page, details page, changes projects, or logs out.</h2>
                     </div>
                 </Tab>
             );
@@ -87,7 +87,7 @@ class Smart extends React.Component {
             adminTabAdminTable = (
                 <Tab eventKey={4} transition={false} title="Skipped Cards" className="full card">
                     <div className="cardContent">
-                        <h2>Another admin is currently using this page. This page will become available when the admin returns to the project list page, changes projects, or logs out.</h2>
+                        <h2>Another admin is currently using this page. This page will become available when the admin returns to the project list page, details page, changes projects, or logs out.</h2>
                     </div>
                 </Tab>
             );
@@ -112,7 +112,7 @@ class Smart extends React.Component {
             adminTabRecycle = (
                 <Tab eventKey={5} transition={false} title={<div><span id="trashCan" className="glyphicon glyphicon-trash" aria-hidden="true"></span> Discarded Data</div>} className="full card">
                     <div className="cardContent">
-                        <h2>Another admin is currently using this page. This page will become available when the admin returns to the project list page, changes projects, or logs out.</h2>
+                        <h2>Another admin is currently using this page. This page will become available when the admin returns to the project list page, details page, changes projects, or logs out.</h2>
                     </div>
                 </Tab>
             );

--- a/frontend/src/components/Smart/index.jsx
+++ b/frontend/src/components/Smart/index.jsx
@@ -35,7 +35,7 @@ class Smart extends React.Component {
             adminTabSkew = (
                 <Tab eventKey={3} transition={false} title="Fix Skew" className="full card">
                     <div className="cardContent">
-                        <h2>Another admin is currently using this page. Please check back later.</h2>
+                        <h2>Another admin is currently using this page. This page will become available when the admin returns to the project list page, changes projects, or logs out.</h2>
                     </div>
                 </Tab>
             );
@@ -87,7 +87,7 @@ class Smart extends React.Component {
             adminTabAdminTable = (
                 <Tab eventKey={4} transition={false} title="Skipped Cards" className="full card">
                     <div className="cardContent">
-                        <h2>Another admin is currently using this page. Please check back later.</h2>
+                        <h2>Another admin is currently using this page. This page will become available when the admin returns to the project list page, changes projects, or logs out.</h2>
                     </div>
                 </Tab>
             );
@@ -112,7 +112,7 @@ class Smart extends React.Component {
             adminTabRecycle = (
                 <Tab eventKey={5} transition={false} title={<div><span id="trashCan" className="glyphicon glyphicon-trash" aria-hidden="true"></span> Discarded Data</div>} className="full card">
                     <div className="cardContent">
-                        <h2>Another admin is currently using this page. Please check back later.</h2>
+                        <h2>Another admin is currently using this page. This page will become available when the admin returns to the project list page, changes projects, or logs out.</h2>
                     </div>
                 </Tab>
             );


### PR DESCRIPTION
This branch patches the leave coding page issues we were seeing where users were locked out of the admin page. It should also give back assigned data. 

NOTE: here leaving the coding page means un-assigning all data assigned to that user, and removing them from the admin-progress table which locks certain admin tables from other admin's use

The changes are as follows:

* when someone enters the coding page for one project, it leaves the coding page for that user for all other projects they have access to
* when someone logs out it leaves the coding page for all projects they have access to

I'd appreciate it if you could both test this thoroughly and let me know what you think! Thanks!