### PR TITLE
Default to external db connection

### DIFF
--- a/backend/django/core/views/frontend.py
+++ b/backend/django/core/views/frontend.py
@@ -162,6 +162,7 @@ class ProjectCreateWizard(LoginRequiredMixin, SessionWizardView):
             kwargs["labels"] = temp
             external_data = self.get_cleaned_data_for_step("external")
             if "engine_database" in external_data:
+                kwargs["database_type"] = external_data["database_type"]
                 kwargs["engine_database"] = external_data["engine_database"]
                 kwargs["ingest_table_name"] = external_data["ingest_table_name"]
                 kwargs["ingest_schema"] = external_data["ingest_schema"]


### PR DESCRIPTION
Django cache method does not work 100% of the time, so this changes into to a more Django-ic way of defaulting to the " Connect to Database and Import Table" radio button.