### PR TITLE
patched data unassigned after being assigned

### DIFF
--- a/backend/django/core/utils/utils_annotate.py
+++ b/backend/django/core/utils/utils_annotate.py
@@ -26,7 +26,7 @@ from core.utils.utils_redis import (
 
 def leave_coding_page(profile, project):
     """unnasign data and remove any admin locks for a specific user and project."""
-    assigned_data = AssignedData.objects.filter(profile=profile)
+    assigned_data = AssignedData.objects.filter(profile=profile, data__project=project)
 
     for assignment in assigned_data:
         unassign_datum(assignment.data, profile)


### PR DESCRIPTION
I referenced this in #205, but this issue prevents data from being labelled due to data being unassigned after getting assigned. Now, I know the issue appears in the main branch.