### PR TITLE
Manual unassign coders

### DIFF
--- a/backend/django/core/templates/projects/admin/admin.html
+++ b/backend/django/core/templates/projects/admin/admin.html
@@ -24,6 +24,9 @@
           <a data-toggle="tab" href="#irr_tab" class="nav-link">IRR</a>
         </li>
         {% endif %}
+        <li class="nav-item" id="unassign_tab_navitem">
+          <a data-toggle="tab" href="#unassign_tab" class="nav-link">Unassign Coder</a>
+        </li>
       </ul>
     </div>
     <div class="tab-content">
@@ -36,6 +39,8 @@
       {% if project.percentage_irr > 0 %}
         {% include "projects/admin/admin_irr.html" %}
       {% endif %}
+
+      {% include "projects/admin/admin_unassign.html" %}
     </div>
   </div>
 </div>

--- a/backend/django/core/templates/projects/admin/admin_unassign.html
+++ b/backend/django/core/templates/projects/admin/admin_unassign.html
@@ -41,7 +41,13 @@
             async: false,
             url: '/api/unassign_coder/'+{{ pk }}+'/'+ profile +'/',
         });
-        $("option[value=" + profile + "]").remove()
+        $("option[value=" + profile + "]").remove();
+
+        if (!$("#coderSelect option").length) {
+            $("#unassignBtn").remove();
+            $("#coderSelect").select2("destroy")
+            $("#coderSelect").replaceWith("<b>No data assigned to coders</b>")
+        }
     })
 </script>
 {% endblock %}

--- a/backend/django/core/templates/projects/admin/admin_unassign.html
+++ b/backend/django/core/templates/projects/admin/admin_unassign.html
@@ -1,0 +1,47 @@
+{% block unassign_tab %}
+{% load static %}
+<div id="unassign_tab" class="tab-pane fade in">
+  <div class="row">
+    <div class="col-md-12 form-group">
+        <h3>Unassign Coder</h3>
+        <p>This page allows you to unassign data from a coder for this project. Please notify the coder before you unassign them.</p>
+            {% if coders|length > 0 %}
+                <select id="coderSelect" class="form-control">
+                {% for coder in coders %}
+                <option value="{{ coder.id }}">{{ coder.user.username }}</option>
+                {% endfor %}
+            {% else %}
+                <b>No data assigned to coders</b>
+            {% endif %}
+        </select>
+    </div>
+    <div class="col-md-12">
+        {% if coders|length > 0 %}
+            <button id="unassignBtn" class="btn btn-primary">Unassign</button>
+        {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts_body %}
+<!-- Searchable dropdowns -->
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js" defer></script>
+<link rel="stylesheet" href="{% static 'select2.css' %}"/>
+<script type="text/javascript" src="{% static 'search_dropdown.js' %}"></script>
+
+<!-- Requests -->
+<script>
+    profile = document.getElementById("coderSelect").value;
+    $("#unassignBtn").click(function(event) {
+        event.preventDefault();
+        $.ajax({
+            type: 'GET',
+            async: false,
+            url: '/api/unassign_coder/'+{{ pk }}+'/'+ profile +'/',
+        });
+        $("option[value=" + profile + "]").remove()
+    })
+</script>
+{% endblock %}

--- a/backend/django/core/templates/projects/static/search_dropdown.js
+++ b/backend/django/core/templates/projects/static/search_dropdown.js
@@ -1,7 +1,9 @@
-$("#permSelect").ready(function(){
-    $("select[id$='profile']").addClass("searchSelect").select2({
-        width: "100%"
-    })
+$().ready(function(){
+    setTimeout( function() {
+        $("select[id='coderSelect']").addClass("searchSelect").select2({
+            width: "100%"
+        })
+    }, 0.1)
 })
 
 $("#permSelect").on("DOMNodeInserted", "tr", function() {

--- a/backend/django/core/urls/api.py
+++ b/backend/django/core/urls/api.py
@@ -75,6 +75,10 @@ adminpage_patterns = [
     re_path(r"^heat_map_data/(?P<project_pk>\d+)/$", api_admin.heat_map_data),
     re_path(r"^perc_agree_table/(?P<project_pk>\d+)/$", api_admin.perc_agree_table),
     re_path(r"^project_status/(?P<project_pk>\d+)/$", api_admin.get_project_status),
+    re_path(
+        r"^unassign_coder/(?P<project_pk>\d+)/(?P<profile_id>\d+)/$",
+        api_admin.unassign_coders,
+    ),
 ]
 
 urlpatterns = [

--- a/backend/django/core/views/api_admin.py
+++ b/backend/django/core/views/api_admin.py
@@ -333,6 +333,7 @@ def get_project_status(request, project_pk):
 
 
 @api_view(["GET"])
+@permission_classes((IsAdminOrCreator,))
 def unassign_coders(request, project_pk, profile_id):
     """Unassigns all data from user for project."""
     project = Project.objects.get(pk=project_pk)

--- a/backend/django/core/views/api_admin.py
+++ b/backend/django/core/views/api_admin.py
@@ -7,19 +7,21 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 
 from core.models import (
+    AssignedData,
     Data,
     DataLabel,
     DataPrediction,
     IRRLog,
     Label,
     Model,
+    Profile,
     Project,
     ProjectPermissions,
     TrainingSet,
 )
 from core.permissions import IsAdminOrCreator, IsCoder
 from core.utils.util import irr_heatmap_data, perc_agreement_table_data, project_status
-from core.utils.utils_annotate import leave_coding_page
+from core.utils.utils_annotate import leave_coding_page, unassign_datum
 from core.utils.utils_model import cohens_kappa, fleiss_kappa
 
 
@@ -328,3 +330,17 @@ def get_project_status(request, project_pk):
     project_details = project_status(project)
 
     return Response(project_details)
+
+
+@api_view(["GET"])
+def unassign_coders(request, project_pk, profile_id):
+    """Unassigns all data from user for project."""
+    project = Project.objects.get(pk=project_pk)
+    profile = Profile.objects.get(pk=profile_id)
+
+    assigned_data = AssignedData.objects.filter(profile=profile, data__project=project)
+    datas = [d.data for d in assigned_data]
+    for d in datas:
+        unassign_datum(d, profile)
+
+    return Response(project_status(project))

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -139,6 +139,14 @@ def skip_data(request, data_pk):
     project = data.project
     response = {}
 
+    # if the coder has been un-assigned from the data
+    if not AssignedData.objects.filter(data=data, profile=profile).exists():
+        response["error"] = (
+            "ERROR: Your cards were un-assigned by an administrator. "
+            "Please refresh the page to get new assigned items to annotate."
+        )
+        return Response(response)
+
     # if the data is IRR or processed IRR, dont add to admin queue yet
     num_history = IRRLog.objects.filter(data=data).count()
 
@@ -189,6 +197,14 @@ def annotate_data(request, data_pk):
     response = {}
     label = Label.objects.get(pk=request.data["labelID"])
     labeling_time = request.data["labeling_time"]
+
+    # if the coder has been un-assigned from the data
+    if not AssignedData.objects.filter(data=data, profile=profile).exists():
+        response["error"] = (
+            "ERROR: Your cards were un-assigned by an administrator. "
+            "Please refresh the page to get new assigned items to annotate."
+        )
+        return Response(response)
 
     num_history = IRRLog.objects.filter(data=data).count()
 

--- a/backend/django/core/views/frontend.py
+++ b/backend/django/core/views/frontend.py
@@ -24,6 +24,7 @@ from core.forms import (
     ProjectWizardForm,
 )
 from core.models import (
+    AssignedData,
     Data,
     ExternalDatabase,
     Label,
@@ -94,8 +95,11 @@ class ProjectAdmin(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
     def get_context_data(self, **kwargs):
         ctx = super(ProjectAdmin, self).get_context_data(**kwargs)
 
-        ctx["project"] = Project.objects.get(pk=self.kwargs["pk"])
-
+        project = Project.objects.get(pk=self.kwargs["pk"])
+        ctx["project"] = project
+        users = AssignedData.objects.filter(data__project=project).distinct("profile")
+        coders = [d.profile for d in users]
+        ctx["coders"] = coders
         return ctx
 
 


### PR DESCRIPTION
Adds the ability to manually unassign data from coders through the Admin dashboard.

For future reference, the manual unassign problem ([EWDCODE-197](https://jira.rti.org/browse/EWDCODE-197)) occurs when the changes in the database (ie removing AssignedData entires) is not reflected in the redis queue that is responsible for distributing data to coders.