### PR TITLE
add profile and timestamp to data export

### DIFF
--- a/backend/django/core/templates/projects/create/create_wizard_external_db.html
+++ b/backend/django/core/templates/projects/create/create_wizard_external_db.html
@@ -73,7 +73,7 @@
                         <div class="error-messages">{{ wizard.form.ingest_schema.errors }}</div>
                         <hr />
                         <p>The following fields are the table name and schema for the database table you wish SMART to export labeled data to.
-                          The output table will be created if it doesn't already exist when data is exported for the first time.  </p>
+                            <b>WARNING:</b> The export table cannot already exist in the database.</p>
                         <div id="export_table_fields">
                             Export Table Name: {{ wizard.form.export_table_name }}
                         </div>

--- a/backend/django/core/templates/projects/create/create_wizard_external_db.html
+++ b/backend/django/core/templates/projects/create/create_wizard_external_db.html
@@ -73,7 +73,7 @@
                         <div class="error-messages">{{ wizard.form.ingest_schema.errors }}</div>
                         <hr />
                         <p>The following fields are the table name and schema for the database table you wish SMART to export labeled data to.
-                            <b>WARNING:</b> The export table cannot already exist in the database.</p>
+                            <b>WARNING:</b> The export table cannot already exist in the database. Please note that SMART will completely drop and rewrite this table each time you export.</p>
                         <div id="export_table_fields">
                             Export Table Name: {{ wizard.form.export_table_name }}
                         </div>

--- a/backend/django/core/templates/projects/update/external_db.html
+++ b/backend/django/core/templates/projects/update/external_db.html
@@ -9,7 +9,7 @@
     <div class="col-md-8 col-md-offset-2">
         <div class="card">
             <div class="cardface">
-              {{ form.media.css }}
+                {{ form.media.css }}
                 <form action="." method="post" enctype="multipart/form-data" id="formObject">
                     {% csrf_token %}
                     <h1>External Database Connection</h1>
@@ -66,7 +66,7 @@
                         <div class="error-messages">{{ form.ingest_schema.errors }}</div>
                         <hr />
                         <p>The following fields are the table name and schema for the database table you wish SMART to export labeled data to.
-                          The output table will be created if it doesn't already exist when data is exported for the first time.</p>
+                            <b>WARNING:</b> The export table cannot already exist in the database.</p>
                         <div id="export_table_fields_update">
                             Export Table Name: {{ form.export_table_name }}
                         </div>
@@ -124,15 +124,12 @@
         }
     });
 
-    $('#submitButton').click(function (e) {
-      if($('input#id_database_type_0').prop('checked') == true){
-        if(! confirm('WARNING: submitting with the option "no database" will remove any existing data base connection. Are you sure you want to submit?'))
-        {
-            e.preventDefault()
+    $('#submitButton').click(function(e) {
+        if ($('input#id_database_type_0').prop('checked') == true) {
+            if (!confirm('WARNING: submitting with the option "no database" will remove any existing data base connection. Are you sure you want to submit?')) {
+                e.preventDefault()
+            }
         }
-      }
     });
-
-
 </script>
 {% endblock %}

--- a/backend/django/core/templates/projects/update/external_db.html
+++ b/backend/django/core/templates/projects/update/external_db.html
@@ -66,7 +66,7 @@
                         <div class="error-messages">{{ form.ingest_schema.errors }}</div>
                         <hr />
                         <p>The following fields are the table name and schema for the database table you wish SMART to export labeled data to.
-                            <b>WARNING:</b> The export table cannot already exist in the database.</p>
+                            <b>WARNING:</b> The export table cannot already exist in the database. Please note that SMART will completely drop and rewrite this table each time you export.</p>
                         <div id="export_table_fields_update">
                             Export Table Name: {{ form.export_table_name }}
                         </div>

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -597,6 +597,8 @@ def get_labeled_data(project):
             for m in metadata:
                 temp[m.metadata_field.field_name] = m.value
             temp["Label"] = label.name
+            temp["Profile"] = d.profile.user
+            temp["Timestamp"] = d.timestamp
             data.append(temp)
     labeled_data_frame = pd.DataFrame(data)
     label_frame = pd.DataFrame(labels)

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -597,7 +597,7 @@ def get_labeled_data(project):
             for m in metadata:
                 temp[m.metadata_field.field_name] = m.value
             temp["Label"] = label.name
-            temp["Profile"] = d.profile.user
+            temp["Profile"] = str(d.profile.user)
             temp["Timestamp"] = d.timestamp
             data.append(temp)
     labeled_data_frame = pd.DataFrame(data)

--- a/backend/django/core/utils/utils_external_db.py
+++ b/backend/django/core/utils/utils_external_db.py
@@ -57,14 +57,16 @@ def test_connection(engine_database, schema, table):
         )
 
 
-def test_schema_exists(engine_database, schema):
+def check_if_schema_exists(engine_database, schema):
     """Check if the given schema exists in the database."""
     schema_set = pd.read_sql(
         sql=f"SELECT schema_name FROM information_schema.schemata WHERE schema_name = '{schema}'",
         con=engine_database,
     )
     if len(schema_set) == 0:
-        raise ValidationError(f"ERROR: schema {schema} not found in the database.")
+        return False
+    else:
+        return True
 
 
 def check_if_table_exists(engine_database, schema, table):

--- a/backend/django/core/views/api.py
+++ b/backend/django/core/views/api.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import zipfile
 
-import pandas as pd
+import sqlalchemy
 from django.conf import settings
 from django.http import HttpResponse
 from rest_framework import status
@@ -248,14 +248,10 @@ def export_database_table(request, project_pk):
                     engine_database = get_connection(
                         external_db.database_type, connection_dict
                     )
-                    table_name_string = (
-                        f"{external_db.export_schema}.{external_db.export_table_name}"
-                    )
 
                     # pull all labeled data
                     data, labels = get_labeled_data(project)
                     if len(data) > 0:
-
                         # pull the export table
                         if check_if_table_exists(
                             engine_database,
@@ -264,23 +260,17 @@ def export_database_table(request, project_pk):
                         ):
                             response[
                                 "success_message"
-                            ] = "Appending labeled data to existing table."
+                            ] = "Table exists. Dropping and replacing with new output data."
 
-                            # Only upload new data. Deduping on upload ID, since duplicate contents
-                            # are deduped when the data is first added
-                            existing_ids = pd.read_sql(
-                                sql=f"SELECT DISTINCT ID FROM {table_name_string}",
+                            # drop the table and then replace the data
+                            data.to_sql(
+                                name=external_db.export_table_name,
                                 con=engine_database,
-                            )["ID"].tolist()
-                            data = data.loc[~data["ID"].isin(existing_ids)]
-                            if len(data) > 0:
-                                data.to_sql(
-                                    name=external_db.export_table_name,
-                                    con=engine_database,
-                                    schema=external_db.export_schema,
-                                    if_exists="append",
-                                    index=False,
-                                )
+                                schema=external_db.export_schema,
+                                if_exists="replace",
+                                index=False,
+                                dtype={"Timestamp": sqlalchemy.DateTime},
+                            )
 
                         else:
                             response[
@@ -293,6 +283,7 @@ def export_database_table(request, project_pk):
                                 schema=external_db.export_schema,
                                 if_exists="fail",
                                 index=False,
+                                dtype={"Timestamp": sqlalchemy.DateTime},
                             )
                     response[
                         "success_message"


### PR DESCRIPTION
This change adds the profile and timestamp to the exports. 

This should be very simple for new projects, but for existing ones, we'll need to think of a workaround. One option is to change the export table name and re-export all items. 

Another would be to add the Profile and Timestamp columns manually and then just have it add those fields for the newly labeled items. Unless this MR should append the columns if they are not there?