### PR TITLE
specify white space for card text

### DIFF
--- a/frontend/src/components/AdminTable/index.jsx
+++ b/frontend/src/components/AdminTable/index.jsx
@@ -54,7 +54,7 @@ class AdminTable extends React.Component {
                             {row.original.message && (
                                 <div className="adjudicate-message">
                                     <h4>Reason for skipping:</h4>
-                                    <p>{row.original.message}</p>
+                                    <p style={{ whiteSpace: "normal" }}>{row.original.message}</p>
                                 </div>
                             )}
                             <AnnotateCard

--- a/frontend/src/components/DataCard/CardData.jsx
+++ b/frontend/src/components/DataCard/CardData.jsx
@@ -17,7 +17,7 @@ export default function CardData({ card, onSkip, onUnassign, showAdjudicate = tr
             )}
             <div className="card-data">
                 <h4>Text to Label</h4>
-                <p>{card.text["text"] || card.text["data"]}</p>
+                <p style={{ whiteSpace: "normal" }}>{card.text["text"] || card.text["data"]}</p>
             </div>
             {extractMetadata(card)}
         </div>


### PR DESCRIPTION
Specifies white space for text in the card's data, as well as the adjudication reason on the adjudicate table, so that the text wraps normally and doesn't overflow.