### PR TITLE
allow toggle for unlabeled data in history table

### DIFF
--- a/frontend/src/actions/history.js
+++ b/frontend/src/actions/history.js
@@ -7,8 +7,10 @@ import { getAdminCounts } from './smart';
 import { getLabelCounts } from './skew';
 
 export const SET_HIST_DATA = 'SET_HIST_DATA';
+export const SET_UNLABELED_DATA = 'SET_UNLABELED_DATA';
 
 export const set_hist_data = createAction(SET_HIST_DATA);
+export const set_unlabeled_data = createAction(SET_UNLABELED_DATA);
 
 //Get the data for the history table
 export const getHistory = (projectID) => {
@@ -44,6 +46,21 @@ export const getHistory = (projectID) => {
                     all_data.push(row);
                 }
                 dispatch(set_hist_data(all_data));
+
+                let unlabeled_data = [];
+                for (let i = 0; i < response.unlabeled.length; i++) {
+                    const row = {
+                        id: response.unlabeled[i].id,
+                        data: response.unlabeled[i].data,
+                        metadata: response.unlabeled[i].metadata,
+                        formattedMetadata: response.unlabeled[i].formattedMetadata,
+                        metadataIDs: response.unlabeled[i].metadataIDs,
+                        edit: response.unlabeled[i].edit,
+                        project: projectID,
+                    };
+                    unlabeled_data.push(row);
+                }
+                dispatch(set_unlabeled_data(unlabeled_data));
             })
             .catch(err => console.log("Error: ", err));
     };

--- a/frontend/src/components/History/historytable.spec.js
+++ b/frontend/src/components/History/historytable.spec.js
@@ -8,12 +8,14 @@ describe('<History />', () => {
         it('renders properly if all props provided', () => {
             const fn = () => {};
             const data = [];
+            const unlabeled_data = [];
             const labels = [];
 
             const wrapper = shallow(
                 <History
                   getHistory = {fn}
                   history_data={data}
+                  unlabeled_data={unlabeled_data}
                   changeLabel = {fn}
                   changeToSkip= {fn}
                   labels={labels}

--- a/frontend/src/components/History/index.jsx
+++ b/frontend/src/components/History/index.jsx
@@ -67,7 +67,8 @@ class History extends React.Component {
         this.historyChangeLabel = this.historyChangeLabel.bind(this);
         this.state = {
             pageSize : parseInt(localStorage.getItem("pageSize") || "25"),
-            showConfirm : false
+            showConfirm: false,
+            showUnlabeled: false
         };
         this.cardID, this.rowID, this.label;
     }
@@ -78,6 +79,10 @@ class History extends React.Component {
 
     componentDidMount() {
         this.props.getHistory();
+    }
+
+    toggleShowUnlabeled() {
+        this.setState({ showUnlabeled : !this.state.showUnlabeled });
     }
 
     getLabelButton(row, label) {
@@ -178,7 +183,7 @@ class History extends React.Component {
     }
 
     render() {
-        const { history_data } = this.props;
+        const { history_data, unlabeled_data } = this.props;
 
         let metadataColumns = [];
         history_data.forEach((data) => {
@@ -236,8 +241,17 @@ class History extends React.Component {
                     <strong>TIP:</strong> In this table you may edit metadata fields. Click on the value in the column and row where you want to change the data and it will open as a text box.
                 </p>
                 <CodebookLabelMenuContainer />
+                <div>
+                    <p style={{ maxWidth: "75ch" }}>
+                        Toggle the checkbox below to show/hide unlabeled data:
+                    </p>
+                    <label>
+                        <input type="checkbox" onChange={() => this.toggleShowUnlabeled()} />
+                        <span style={{ marginLeft: "4px" }}>Unlabled Data</span>
+                    </label>
+                </div>
                 <ReactTable
-                    data={history_data}
+                    data={this.state.showUnlabeled ? [...history_data, ...unlabeled_data] : history_data}
                     columns={[...COLUMNS, ...metadataColumns.map((column, i) => {
                         return {
                             Header: () => (

--- a/frontend/src/containers/history_container.jsx
+++ b/frontend/src/containers/history_container.jsx
@@ -11,6 +11,7 @@ const HistoryContainer = (props) => <History {...props} />;
 const mapStateToProps = (state) => {
     return {
         history_data: state.history.history_data,
+        unlabeled_data: state.history.unlabeled_data,
         labels: state.card.labels
     };
 };

--- a/frontend/src/reducers/history.js
+++ b/frontend/src/reducers/history.js
@@ -1,15 +1,19 @@
 import { handleActions } from 'redux-actions';
 import update from 'immutability-helper';
 
-import { SET_HIST_DATA } from '../actions/history';
+import { SET_HIST_DATA, SET_UNLABELED_DATA } from '../actions/history';
 
 const initialState = {
-    history_data: []
+    history_data: [],
+    unlabeled_data: []
 };
 
 const history = handleActions({
     [SET_HIST_DATA]: (state, action) => {
         return update(state, { history_data: { $set: action.payload } } );
+    },
+    [SET_UNLABELED_DATA]: (state, action) => {
+        return update(state, { unlabeled_data: { $set: action.payload } });
     }
 }, initialState);
 


### PR DESCRIPTION
Two thoughts:

- Depending on how many unlabeled data are in a project, a little worried about how long requests to get all of the data could take... thoughts?
- Noticing some weird/lagging search results for some metadata columns in the History table