### PR TITLE
reset batch page when filtering so you don't get stuck

### DIFF
--- a/frontend/src/components/History/index.jsx
+++ b/frontend/src/components/History/index.jsx
@@ -259,6 +259,8 @@ class History extends React.Component {
     filterHistory(event) {
         // Update official filter state and re-pull history table
         event.preventDefault();
+        // always reset page when applying new filter
+        this.props.set_current_page(1);
         this.props.filterHistoryTable(this.state.temp_filters);
     }
 
@@ -278,6 +280,8 @@ class History extends React.Component {
         this.setState({
             temp_filters: current_filters
         });
+        // always reset page when applying new filter
+        this.props.set_current_page(1);
         this.props.filterHistoryTable(this.state.temp_filters);
     }
 


### PR DESCRIPTION
Quick bug fix for issue found in filtering. Basically if you go to a high batch and then filter, the batch number doesn't reset and the history table is then trying to return the fifth page of results that may not go that far. Thus you typically get nothing and the batch dropdown dissapears.