### PR TITLE
Fix broken label guide

### DIFF
--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -64,7 +64,11 @@ def read_data_file(data_file):
         elif data_file.content_type.startswith(
             "application/vnd"
         ) and data_file.name.endswith(".xlsx"):
-            data = pd.read_excel(data_file, dtype=str).dropna(axis=0, how="all").replace(r'\n',' ', regex=True)
+            data = (
+                pd.read_excel(data_file, dtype=str)
+                .dropna(axis=0, how="all")
+                .replace(r"\n", " ", regex=True)
+            )
         else:
             raise ValidationError(
                 "File type is not supported.  Received {0} but only {1} are supported.".format(

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -749,8 +749,7 @@ def get_projects_umbrellas(self):
 
 
 def get_unlabelled_data_objs(project_id: int) -> int:
-    """
-    Function to retrieve the total count of unlabelled data objects for a project.
+    """Function to retrieve the total count of unlabelled data objects for a project.
 
     This SQL query is comprised of 5 subqueries, each of which retrieves the ids of
     data objects that are in a particular table. The first sub-query is the total list
@@ -799,7 +798,7 @@ def get_unlabelled_data_objs(project_id: int) -> int:
         )
         SELECT COUNT(*)
             FROM (
-                SELECT p.id 
+                SELECT p.id
                 FROM project_ids p
                 LEFT JOIN queue_ids q ON p.id = q.id
                 LEFT JOIN irr_log_ids irr ON p.id = irr.id

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -1109,22 +1109,3 @@ def modify_metadata_values(request, data_pk):
         metadata.value = m["value"]
         metadata.save()
     return Response({})
-
-
-@api_view(["GET"])
-@permission_classes((IsCoder,))
-def get_labels(request, project_pk):
-    """Grab data using get_assignments and send it to the frontend react app.
-
-    Args:
-        request: The request to the endpoint
-        project_pk: Primary key of project
-    Returns:
-        labels: The project labels
-        data: The data in the queue
-    """
-    project = Project.objects.get(pk=project_pk)
-    labels = Label.objects.all().filter(project=project)
-
-    return Response({"labels": LabelSerializer(labels, many=True).data,})
-

--- a/frontend/src/actions/smart.js
+++ b/frontend/src/actions/smart.js
@@ -4,8 +4,11 @@ import 'whatwg-fetch';
 import { getConfig } from '../utils/fetch_configs';
 
 export const SET_AVAILABLE = 'SET_AVAILABLE';
+export const SET_LABEL = 'SET_LABEL';
+
 
 export const set_available = createAction(SET_AVAILABLE);
+export const setLabel = createAction(SET_LABEL);
 
 //check if another admin is already using the admin tabs
 export const getAdminTabsAvailable = (projectID) => {
@@ -35,3 +38,25 @@ export const getAdminTabsAvailable = (projectID) => {
     };
 };
 
+// Get the set of labels for the project
+export const getLabels = (projectID) => {
+    let apiURL = `/api/get_labels/${projectID}/`;
+    return dispatch => {
+        return fetch(apiURL, getConfig())
+            .then(response => {
+                if (response.ok) {
+                    return response.json();
+                } else {
+                    const error = new Error(response.statusText);
+                    error.response = response;
+                    throw error;
+                }
+            })
+            .then(response => {
+                // If error was in the response then set that message
+                if ('error' in response) console.log(response);
+                dispatch(setLabel(response.labels));
+            })
+            .catch(err => console.log("Error: ", err));
+    };
+};

--- a/frontend/src/components/Smart/index.jsx
+++ b/frontend/src/components/Smart/index.jsx
@@ -19,6 +19,7 @@ class Smart extends React.Component {
 
     componentDidMount() {
         this.props.getAdminTabsAvailable();
+        this.props.getLabels();
     }
 
     renderAdminTabSkew() {
@@ -130,6 +131,7 @@ class Smart extends React.Component {
 
 Smart.propTypes = {
     adminTabsAvailable: PropTypes.bool,
+    getLabels: PropTypes.func.isRequired,
 };
 
 export default Smart;

--- a/frontend/src/containers/smart_container.jsx
+++ b/frontend/src/containers/smart_container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { getAdminTabsAvailable } from '../actions/smart';
+import { getAdminTabsAvailable, getLabels } from '../actions/smart';
 import Smart from '../components/Smart';
 
 const PROJECT_ID = window.PROJECT_ID;
@@ -20,6 +20,9 @@ const mapDispatchToProps = (dispatch) => {
         getAdminTabsAvailable: () => {
             dispatch(getAdminTabsAvailable(PROJECT_ID));
         },
+        getLabels: () => {
+            dispatch(getLabels(PROJECT_ID));
+        }
     };
 };
 


### PR DESCRIPTION
The recent table upgrades swapped some of the React components from class-based to functional. However, since not everything was swapped over we ended up with some hiccups. The CodebookLabelMenu is still a class-based component which relies on a getLabel action that was removed when the useLabels hook was created. Trouble is that the class-based components can't use the hook, and so still need the old action. Adding back in the action code fixed the issue.

Long-term we will want everything to be moved over to functional components so we don't have this sort of duplication. However, I don't recommend we try and do that right now as we want to deploy recent changes in the near term.
