### PR TITLE
fix broken timezone issue and some linting

### DIFF
--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -64,7 +64,11 @@ def read_data_file(data_file):
         elif data_file.content_type.startswith(
             "application/vnd"
         ) and data_file.name.endswith(".xlsx"):
-            data = pd.read_excel(data_file, dtype=str).dropna(axis=0, how="all").replace(r'\n',' ', regex=True)
+            data = (
+                pd.read_excel(data_file, dtype=str)
+                .dropna(axis=0, how="all")
+                .replace(r"\n", " ", regex=True)
+            )
         else:
             raise ValidationError(
                 "File type is not supported.  Received {0} but only {1} are supported.".format(

--- a/backend/django/core/serializers.py
+++ b/backend/django/core/serializers.py
@@ -85,7 +85,7 @@ class DataMetadataIDSerializer(serializers.ModelSerializer):
 class DataLabelModelSerializer(serializers.ModelSerializer):
     profile = serializers.StringRelatedField(many=False, read_only=True)
     timestamp = serializers.DateTimeField(
-        default_timezone=pytz.timezone(TIME_ZONE_FRONTEND), format="%Y-%m-%d, %I:%m %p"
+        default_timezone=pytz.timezone(TIME_ZONE_FRONTEND), format="%Y-%m-%d, %I:%M %p"
     )
     verified = serializers.StringRelatedField(many=False, read_only=True)
 
@@ -103,7 +103,7 @@ class DataLabelSerializer(serializers.HyperlinkedModelSerializer):
 class IRRLogModelSerializer(serializers.ModelSerializer):
     profile = serializers.StringRelatedField(many=False, read_only=True)
     timestamp = serializers.DateTimeField(
-        default_timezone=pytz.timezone(TIME_ZONE_FRONTEND), format="%Y-%m-%d, %I:%m %p"
+        default_timezone=pytz.timezone(TIME_ZONE_FRONTEND), format="%Y-%m-%d, %I:%M %p"
     )
 
     class Meta:

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -630,8 +630,8 @@ def get_labeled_data(project, unverified=True):
                 temp["Description"] = label.description
             temp["Profile"] = str(d.profile.user)
             if d.timestamp:
-                temp["Timestamp"] = pytz.timezone(TIME_ZONE_FRONTEND).normalize(
-                    d.timestamp
+                temp["Timestamp"] = d.timestamp.astimezone(
+                    pytz.timezone(TIME_ZONE_FRONTEND)
                 )
             else:
                 temp["Timestamp"] = None
@@ -639,9 +639,9 @@ def get_labeled_data(project, unverified=True):
                 v = VerifiedDataLabel.objects.get(data_label=d)
                 temp["Verified"] = "Yes"
                 temp["Verified By"] = str(v.verified_by.user)
-                temp["Verified Timestamp"] = pytz.timezone(
-                    TIME_ZONE_FRONTEND
-                ).normalize(v.verified_timestamp)
+                temp["Verified Timestamp"] = v.verified_timestamp.astimezone(
+                    pytz.timezone(TIME_ZONE_FRONTEND)
+                )
             else:
                 temp["Verified"] = "No"
                 temp["Verified By"] = None
@@ -749,8 +749,7 @@ def get_projects_umbrellas(self):
 
 
 def get_unlabelled_data_objs(project_id: int) -> int:
-    """
-    Function to retrieve the total count of unlabelled data objects for a project.
+    """Function to retrieve the total count of unlabelled data objects for a project.
 
     This SQL query is comprised of 5 subqueries, each of which retrieves the ids of
     data objects that are in a particular table. The first sub-query is the total list
@@ -799,7 +798,7 @@ def get_unlabelled_data_objs(project_id: int) -> int:
         )
         SELECT COUNT(*)
             FROM (
-                SELECT p.id 
+                SELECT p.id
                 FROM project_ids p
                 LEFT JOIN queue_ids q ON p.id = q.id
                 LEFT JOIN irr_log_ids irr ON p.id = irr.id

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -1109,22 +1109,3 @@ def modify_metadata_values(request, data_pk):
         metadata.value = m["value"]
         metadata.save()
     return Response({})
-
-
-@api_view(["GET"])
-@permission_classes((IsCoder,))
-def get_labels(request, project_pk):
-    """Grab data using get_assignments and send it to the frontend react app.
-
-    Args:
-        request: The request to the endpoint
-        project_pk: Primary key of project
-    Returns:
-        labels: The project labels
-        data: The data in the queue
-    """
-    project = Project.objects.get(pk=project_pk)
-    labels = Label.objects.all().filter(project=project)
-
-    return Response({"labels": LabelSerializer(labels, many=True).data,})
-

--- a/backend/django/smart/settings.py
+++ b/backend/django/smart/settings.py
@@ -28,7 +28,13 @@ class Dev(Configuration):
     # SECURITY WARNING: don't run with debug turned on in production!
     DEBUG = True
 
-    ALLOWED_HOSTS = ["0.0.0.0", "localhost", "backend", "smart-coding.rti.org", "cds-mallard.rtp.rti.org"]
+    ALLOWED_HOSTS = [
+        "0.0.0.0",
+        "localhost",
+        "backend",
+        "smart-coding.rti.org",
+        "cds-mallard.rtp.rti.org",
+    ]
 
     # Application definition
 

--- a/backend/django/smart/urls.py
+++ b/backend/django/smart/urls.py
@@ -13,9 +13,10 @@ Including another URLconf
     1. Import the include() function: from django.urls import re_path, include
     2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
-from django.urls import include, re_path
 from django.contrib import admin
 from django.http import HttpResponseRedirect
+from django.urls import include, re_path
+
 # from rest_framework_swagger.views import get_swagger_view
 
 urlpatterns = [


### PR DESCRIPTION
This addresses two issues:

1. The download labeled data was broken by one of the recent upgrades. The timezone normalizing was causing an error.
2. A typo was discovered in the history table datetime rendering. %m was being used to render the minutes but %m is month and %M is minute. 