### PR TITLE
Dev fix history unlabeled

### DIFF
--- a/backend/django/core/templates/projects/detail.html
+++ b/backend/django/core/templates/projects/detail.html
@@ -389,7 +389,7 @@ $(document).ready(function() {
       $('#fully-labeled').append(response.final);
       $('#fully-labeled-verified').append(response.final_verified);
       $('#fully-labeled-unverified').append(response.final_unverified);
-      $('#unlabeled-unassigned').append(response.unlabeled - response.assigned);
+      $('#unlabeled-unassigned').append(response.unlabeled);
       $('#awaiting-adjudication').append(response.adjudication);
       $('#recycled').append(response.recycled);
       $('#other-labeled').append((response.total - response.final - response.adjudication - response.recycled) - response.unlabeled);

--- a/backend/django/core/templates/projects/detail.html
+++ b/backend/django/core/templates/projects/detail.html
@@ -389,7 +389,7 @@ $(document).ready(function() {
       $('#fully-labeled').append(response.final);
       $('#fully-labeled-verified').append(response.final_verified);
       $('#fully-labeled-unverified').append(response.final_unverified);
-      $('#unlabeled-unassigned').append(response.unlabeled);
+      $('#unlabeled-unassigned').append(response.unlabeled - response.assigned);
       $('#awaiting-adjudication').append(response.adjudication);
       $('#recycled').append(response.recycled);
       $('#other-labeled').append((response.total - response.final - response.adjudication - response.recycled) - response.unlabeled);

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -773,25 +773,25 @@ def get_unlabelled_data_objs(project_id: int) -> int:
             WHERE cd.project_id = %s AND cdl.label_id IS NULL
         ),
         queue_ids AS (
-            SELECT cdq.id
+            SELECT cdq.id, cdq.data_id
             FROM core_dataqueue cdq
             LEFT JOIN core_queue cq ON cdq.queue_id = cq.id
             WHERE cq.project_id = %s AND cq.type = 'admin'
         ),
         irr_log_ids AS (
-            SELECT ci.id
+            SELECT ci.id, ci.data_id
             FROM core_irrlog ci
             LEFT JOIN core_data cd ON ci.data_id = cd.id
             WHERE cd.project_id = %s
         ),
         assigned_ids AS (
-            SELECT ca.id
+            SELECT ca.id, ca.data_id
             FROM core_assigneddata ca
             LEFT JOIN core_data cd ON ca.data_id = cd.id
             WHERE cd.project_id = %s
         ),
         recycle_ids AS (
-            SELECT cr.id
+            SELECT cr.id, cr.data_id
             FROM core_recyclebin cr
             LEFT JOIN core_data cd ON cr.data_id = cd.id
             WHERE cd.project_id = %s
@@ -800,10 +800,10 @@ def get_unlabelled_data_objs(project_id: int) -> int:
             FROM (
                 SELECT p.id
                 FROM project_ids p
-                LEFT JOIN queue_ids q ON p.id = q.id
-                LEFT JOIN irr_log_ids irr ON p.id = irr.id
-                LEFT JOIN assigned_ids a ON p.id = a.id
-                LEFT JOIN recycle_ids r ON p.id = r.id
+                LEFT JOIN queue_ids q ON p.id = q.data_id
+                LEFT JOIN irr_log_ids irr ON p.id = irr.data_id
+                LEFT JOIN assigned_ids a ON p.id = a.data_id
+                LEFT JOIN recycle_ids r ON p.id = r.data_id
                 WHERE q.id IS NULL
                     AND irr.id IS NULL
                     AND a.id IS NULL

--- a/backend/django/core/utils/utils_annotate.py
+++ b/backend/django/core/utils/utils_annotate.py
@@ -267,15 +267,23 @@ def process_irr_label(data, label):
 def get_unlabeled_data(project_pk):
     project = Project.objects.get(pk=project_pk)
 
-    stuff_in_queue = DataQueue.objects.filter(queue__project=project)
-    queued_ids = [queued.data.id for queued in stuff_in_queue]
+    stuff_in_queue = DataQueue.objects.filter(
+        queue__project=project, queue__type="admin"
+    )
+    in_admin_queue_ids = [queued.data.id for queued in stuff_in_queue]
 
     recycle_ids = RecycleBin.objects.filter(data__project=project).values_list(
         "data__pk", flat=True
     )
+
+    assigned_ids = AssignedData.objects.filter(data__project=project).values_list(
+        "data__pk", flat=True
+    )
+
     unlabeled_data = (
         project.data_set.filter(datalabel__isnull=True)
-        .exclude(id__in=queued_ids)
+        .exclude(id__in=in_admin_queue_ids)
+        .exclude(id__in=assigned_ids)
         .exclude(id__in=recycle_ids)
         .exclude(irr_ind=True)
     )

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -469,6 +469,9 @@ def modify_label(request, data_pk):
         and not DataLabel.objects.filter(data=data).exists()
     ):
         current_training_set = project.get_current_training_set()
+        data_in_normal_queue = DataQueue.objects.filter(
+            data=data, queue=normal_queue
+        ).exists()
         with transaction.atomic():
             DataLabel.objects.create(
                 data=data,
@@ -479,8 +482,13 @@ def modify_label(request, data_pk):
                 training_set=current_training_set,
                 pre_loaded=False,
             )
-            if DataQueue.objects.filter(data=data, queue=normal_queue).exists():
+            if data_in_normal_queue:
                 DataQueue.objects.get(data=data, queue=normal_queue).delete()
+
+        if data_in_normal_queue:
+            settings.REDIS.srem(
+                redis_serialize_set(normal_queue), redis_serialize_data(data)
+            )
 
     elif "oldLabelID" in request.data:
         old_label = Label.objects.get(pk=request.data["oldLabelID"])
@@ -862,6 +870,9 @@ def label_skew_label(request, data_pk):
 
     current_training_set = project.get_current_training_set()
     if project_extras.proj_permission_level(datum.project, profile) >= 2:
+        data_in_normal_queue = DataQueue.objects.filter(
+            data=datum, queue=normal_queue
+        ).exists()
         with transaction.atomic():
             dl = DataLabel.objects.create(
                 data=datum,
@@ -871,10 +882,14 @@ def label_skew_label(request, data_pk):
                 time_to_label=None,
                 timestamp=timezone.now(),
             )
-            if DataQueue.objects.filter(data=datum, queue=normal_queue).exists():
+            if data_in_normal_queue:
                 DataQueue.objects.get(data=datum, queue=normal_queue).delete()
             VerifiedDataLabel.objects.create(
                 data_label=dl, verified_timestamp=timezone.now(), verified_by=profile
+            )
+        if data_in_normal_queue:
+            settings.REDIS.srem(
+                redis_serialize_set(normal_queue), redis_serialize_data(datum)
             )
 
     else:

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -460,6 +460,7 @@ def modify_label(request, data_pk):
     profile = request.user.profile
     response = {}
     project = data.project
+    normal_queue = Queue.objects.get(project=project, type="normal")
 
     label = Label.objects.get(pk=request.data["labelID"])
 
@@ -478,6 +479,9 @@ def modify_label(request, data_pk):
                 training_set=current_training_set,
                 pre_loaded=False,
             )
+            if DataQueue.objects.filter(data=data, queue=normal_queue).exists():
+                DataQueue.objects.get(data=data, queue=normal_queue).delete()
+
     elif "oldLabelID" in request.data:
         old_label = Label.objects.get(pk=request.data["oldLabelID"])
         with transaction.atomic():
@@ -842,6 +846,7 @@ def label_skew_label(request, data_pk):
     label = Label.objects.get(pk=request.data["labelID"])
     profile = request.user.profile
     update_last_action(project, profile)
+    normal_queue = Queue.objects.get(project=project, type="normal")
     response = {}
 
     # check if they have the admin lock still.
@@ -866,6 +871,8 @@ def label_skew_label(request, data_pk):
                 time_to_label=None,
                 timestamp=timezone.now(),
             )
+            if DataQueue.objects.filter(data=datum, queue=normal_queue).exists():
+                DataQueue.objects.get(data=datum, queue=normal_queue).delete()
             VerifiedDataLabel.objects.create(
                 data_label=dl, verified_timestamp=timezone.now(), verified_by=profile
             )

--- a/frontend/src/components/History/HistoryTable.jsx
+++ b/frontend/src/components/History/HistoryTable.jsx
@@ -229,6 +229,7 @@ const HistoryTable = () => {
                                 <p>
                                     Toggle the checkbox below to show/hide unlabeled data:
                                 </p>
+                                <i>NOTE: Data assigned to someone in the Annotate Data tab will not be returned. Admin can go to the Unassign Coder tab on the Admin page to un-assign data from individual coders.</i>
                                 <Form.Label className="d-flex m-0 p-0">
                                     <Form.Check
                                         className="p-0"


### PR DESCRIPTION
The function to show unlabeled data was ignoring data in the "normal" queue instead of ignoring assigned data. The normal queue is the precursor to assignments, and is filled automatically by SMART when data is uploaded or the items in the existing queue are labeled. 

The affect of this issue was that there was ~30 unlabeled data that wouldn't show up in the skew page or when someone selected "unlabeled data" in the history table, even if it wasn't assigned to anyone. The fix is two parts: first to stop excluding items in the normal queue when returning unlabeled data, and second when unlabeled data that is in the normal queue is labeled in the history or skew page we need to remove it from the queue so it doesn't ever get assigned. 
