### PR TITLE
Handle bug where the same card was appearing multiple times

### DIFF
--- a/backend/django/core/utils/utils_annotate.py
+++ b/backend/django/core/utils/utils_annotate.py
@@ -169,17 +169,18 @@ def label_data(label, datum, profile, time):
     irr_data = datum.irr_ind
 
     with transaction.atomic():
-        if DataLabel.objects.filter(data=datum,profile=profile).exists():
-            return
-
-        DataLabel.objects.create(
+        dl, created = DataLabel.objects.get_or_create(
             data=datum,
             label=label,
             profile=profile,
             training_set=current_training_set,
-            time_to_label=time,
-            timestamp=timezone.now(),
         )
+        # was not created because it already existed
+        if not created:
+            return
+        dl.time_to_label = time
+        dl.timestamp = timezone.now()
+        dl.save()
         # There's a unique constraint on data/profile, so this is
         # guaranteed to return one object
         assignment = AssignedData.objects.filter(data=datum, profile=profile).get()

--- a/backend/django/core/utils/utils_annotate.py
+++ b/backend/django/core/utils/utils_annotate.py
@@ -169,6 +169,9 @@ def label_data(label, datum, profile, time):
     irr_data = datum.irr_ind
 
     with transaction.atomic():
+        if DataLabel.objects.filter(data=datum,profile=profile).exists():
+            return
+
         DataLabel.objects.create(
             data=datum,
             label=label,

--- a/frontend/src/actions/card.js
+++ b/frontend/src/actions/card.js
@@ -70,13 +70,12 @@ export const annotateCard = (dataID, labelID, num_cards_left, start_time, projec
                     dispatch(clearDeck());
                     return dispatch(setMessage(response.error));
                 } else {
-                    dispatch(popCard());
+                    dispatch(popCard(dataID));
                     if (is_admin) {
                         dispatch(getAdmin(projectID));
                         queryClient.invalidateQueries(["adminCounts", projectID]);
                         dispatch(getLabelCounts(projectID));
                     }
-                    if (num_cards_left <= 1) dispatch(fetchCards(projectID));
                 }
             });
     };
@@ -101,8 +100,7 @@ export const unassignCard = (dataID, num_cards_left, is_admin, projectID) => {
                     dispatch(clearDeck());
                     return dispatch(setMessage(response.error));
                 } else {
-                    dispatch(popCard());
-                    if (num_cards_left <= 1) dispatch(fetchCards(projectID));
+                    dispatch(popCard(dataID));
                 }
             });
     };
@@ -127,12 +125,11 @@ export const passCard = (dataID, num_cards_left, is_admin, projectID, message) =
                     dispatch(clearDeck());
                     return dispatch(setMessage(response.error));
                 } else {
-                    dispatch(popCard());
+                    dispatch(popCard(dataID));
                     if (is_admin) {
                         dispatch(getAdmin(projectID));
                         queryClient.invalidateQueries(["adminCounts", projectID]);
                     }
-                    if (num_cards_left <= 1) dispatch(fetchCards(projectID));
                 }
             });
     };

--- a/frontend/src/containers/card_container.jsx
+++ b/frontend/src/containers/card_container.jsx
@@ -10,9 +10,11 @@ import DataCard, { PAGES } from "../components/DataCard/DataCard";
 const PROJECT_ID = window.PROJECT_ID;
 
 const CardContainer = (props) => {
-    if (props.cards.length == 0) {
-        props.fetchCards();
-    }
+    React.useEffect(() => {
+        if (props.cards.length === 0) {
+            props.fetchCards();
+        }
+    }, [props.cards.length]);
     return (
         props.cards !== undefined && props.cards.length > 0 ? 
             <DataCard 

--- a/frontend/src/reducers/card.js
+++ b/frontend/src/reducers/card.js
@@ -30,12 +30,13 @@ const card = handleActions({
         return update(state, { cards: { $splice: [[0, 1]] } } );
     },
     [PUSH_CARD]: (state, action) => {
-        // Set the start time of the new top card to the current time
+        // only push the card if it's not already in the stack - failsafe
         for (let i = 0; i < state.cards.length; i++) {
             if (state.cards[i].id == action.payload.id) {
                 return state;
             }
         }
+        // Set the start time of the new top card to the current time
         if (state.cards.length > 0) {
             state.cards[0]['start_time'] = moment();
         }

--- a/frontend/src/reducers/card.js
+++ b/frontend/src/reducers/card.js
@@ -11,15 +11,9 @@ const initialState = {
 
 const card = handleActions({
     [POP_CARD]: (state, action) => {
-        // if the card isn't in the deck don't pop it off
+        // if the card isn't the first item in the deck don't pop it off
         // This handles double-clicking of Skip
-        let found_card = false;
-        for (let i = 0; i < state.cards.length; i++) {
-            if (state.cards[i].text.pk == action.payload) {
-                found_card = true;
-            }
-        }
-        if (! found_card) {
+        if (state.cards[0].text.pk != action.payload) {
             return state;
         }
 

--- a/frontend/src/reducers/card.js
+++ b/frontend/src/reducers/card.js
@@ -10,7 +10,19 @@ const initialState = {
 };
 
 const card = handleActions({
-    [POP_CARD]: (state) => {
+    [POP_CARD]: (state, action) => {
+        // if the card isn't in the deck don't pop it off
+        // This handles double-clicking of Skip
+        let found_card = false;
+        for (let i = 0; i < state.cards.length; i++) {
+            if (state.cards[i].text.pk == action.payload) {
+                found_card = true;
+            }
+        }
+        if (! found_card) {
+            return state;
+        }
+
         // Set the start time of the new top card to the current time
         if (state.cards.length > 1) {
             state.cards[1]['start_time'] = moment();

--- a/frontend/src/reducers/card.js
+++ b/frontend/src/reducers/card.js
@@ -19,6 +19,11 @@ const card = handleActions({
     },
     [PUSH_CARD]: (state, action) => {
         // Set the start time of the new top card to the current time
+        for (let i = 0; i < state.cards.length; i++) {
+            if (state.cards[i].id == action.payload.id) {
+                return state;
+            }
+        }
         if (state.cards.length > 0) {
             state.cards[0]['start_time'] = moment();
         }


### PR DESCRIPTION
This MR addresses a bug which was occurring whenever someone either:
* finished the batch of cards handed out
* double clicked on a card

Either action would cause SMART to call `fetchCards` multiple times which would lead to the same card deck being pushed two to three times to the card state on the front end. 

I looked around for the reason this was happening. Even if you comment out all calls to fetchCards that run after actions and only leave the one in the CardContainer constructor the double call still occurs (which suggests to me that the constructor call is the source. @andykawabata any thoughts on where this call should go so that fetchCards runs when the component is mounted?). 

This MR is a workaround that makes the pushCard action check if a card already exists in the deck before pushing. It also adds more error handling for double-clicking since sometimes the first check doesn't catch it. 

