### PR TITLE
Fix logic error in POP_CARD reducer and change name to REMOVE_CARD

### DIFF
--- a/frontend/src/actions/card.js
+++ b/frontend/src/actions/card.js
@@ -8,13 +8,13 @@ import { getLabelCounts, getUnlabeled } from './skew';
 
 import { queryClient } from "../store";
 
-export const POP_CARD = 'POP_CARD';
+export const REMOVE_CARD = 'REMOVE_CARD';
 export const PUSH_CARD = 'PUSH_CARD';
 
 export const SET_MESSAGE = 'SET_MESSAGE';
 export const CLEAR_DECK = 'CLEAR_DECK';
 
-export const popCard = createAction(POP_CARD);
+export const removeCard = createAction(REMOVE_CARD);
 export const pushCard = createAction(PUSH_CARD);
 export const setMessage = createAction(SET_MESSAGE);
 export const clearDeck = createAction(CLEAR_DECK);
@@ -70,7 +70,7 @@ export const annotateCard = (dataID, labelID, num_cards_left, start_time, projec
                     dispatch(clearDeck());
                     return dispatch(setMessage(response.error));
                 } else {
-                    dispatch(popCard(dataID));
+                    dispatch(removeCard(dataID));
                     if (is_admin) {
                         dispatch(getAdmin(projectID));
                         queryClient.invalidateQueries(["adminCounts", projectID]);
@@ -100,7 +100,7 @@ export const unassignCard = (dataID, num_cards_left, is_admin, projectID) => {
                     dispatch(clearDeck());
                     return dispatch(setMessage(response.error));
                 } else {
-                    dispatch(popCard(dataID));
+                    dispatch(removeCard(dataID));
                 }
             });
     };
@@ -125,7 +125,7 @@ export const passCard = (dataID, num_cards_left, is_admin, projectID, message) =
                     dispatch(clearDeck());
                     return dispatch(setMessage(response.error));
                 } else {
-                    dispatch(popCard(dataID));
+                    dispatch(removeCard(dataID));
                     if (is_admin) {
                         dispatch(getAdmin(projectID));
                         queryClient.invalidateQueries(["adminCounts", projectID]);

--- a/frontend/src/reducers/card.js
+++ b/frontend/src/reducers/card.js
@@ -2,7 +2,7 @@ import { handleActions } from 'redux-actions';
 import update from 'immutability-helper';
 import moment from 'moment';
 
-import { POP_CARD, PUSH_CARD, SET_MESSAGE, CLEAR_DECK } from '../actions/card';
+import { REMOVE_CARD, PUSH_CARD, SET_MESSAGE, CLEAR_DECK } from '../actions/card';
 
 const initialState = {
     cards: [],
@@ -10,24 +10,22 @@ const initialState = {
 };
 
 const card = handleActions({
-    [POP_CARD]: (state, action) => {
-        // if the card isn't in the deck don't pop it off
-        // This handles double-clicking of Skip
-        let found_card = false;
+    [REMOVE_CARD]: (state, action) => {
+        let indexToRemove = -1;
         for (let i = 0; i < state.cards.length; i++) {
             if (state.cards[i].text.pk == action.payload) {
-                found_card = true;
+                indexToRemove = i; 
+                break;
             }
         }
-        if (! found_card) {
-            return state;
+        if (indexToRemove === -1) {
+            return state; 
         }
-
-        // Set the start time of the new top card to the current time
-        if (state.cards.length > 1) {
-            state.cards[1]['start_time'] = moment();
+        const newState = update(state, { cards: { $splice: [[indexToRemove, 1]] } });
+        if (newState.cards.length > 0) {
+            newState.cards[0].start_time = moment();
         }
-        return update(state, { cards: { $splice: [[0, 1]] } } );
+        return newState;
     },
     [PUSH_CARD]: (state, action) => {
         // Set the start time of the new top card to the current time


### PR DESCRIPTION
Previously the data id was being passed to `POP_CARD` but the item at index 0 was getting removed regardless of the actual index of the found data.

Also since we are specifying the data id it is no long a "pop" operation, so changed the name to `REMOVE_CARD`