### PR TITLE
Display each user's labels when adjudicating IRR mismatches

### DIFF
--- a/backend/django/core/urls/api.py
+++ b/backend/django/core/urls/api.py
@@ -85,6 +85,7 @@ adminpage_patterns = [
     re_path(r"^get_irr_metrics/(?P<project_pk>\d+)/$", api_admin.get_irr_metrics),
     re_path(r"^heat_map_data/(?P<project_pk>\d+)/$", api_admin.heat_map_data),
     re_path(r"^perc_agree_table/(?P<project_pk>\d+)/$", api_admin.perc_agree_table),
+    re_path(r"^irr_log/(?P<project_pk>\d+)/$", api_admin.irr_log),
     re_path(r"^project_status/(?P<project_pk>\d+)/$", api_admin.get_project_status),
     re_path(
         r"^unassign_coder/(?P<project_pk>\d+)/(?P<profile_id>\d+)/$",

--- a/backend/django/core/views/api_admin.py
+++ b/backend/django/core/views/api_admin.py
@@ -303,11 +303,11 @@ def irr_log(request, project_pk):
     for log in irr_logs:
         data_id = log.data_id
         username = log.profile.user.username
-        label = log.label.name
+        label_id = log.label_id
 
         if data_id not in data_labels:
             data_labels[data_id] = {"data_id": data_id} 
-        data_labels[data_id][username] = label
+        data_labels[data_id][username] = label_id
 
     response_data = list(data_labels.values())
 

--- a/backend/django/core/views/api_admin.py
+++ b/backend/django/core/views/api_admin.py
@@ -286,6 +286,34 @@ def perc_agree_table(request, project_pk):
     user_agree = perc_agreement_table_data(project)
     return Response({"data": user_agree})
 
+@api_view(["GET"])
+@permission_classes((IsAdminOrCreator,))
+def irr_log(request, project_pk):
+    """Gets IRR user labels for a project. 
+    Only gets IRR logs with label disagreements i.e. data in the admin queue."""
+    project = Project.objects.get(pk=project_pk)
+
+    irr_logs = IRRLog.objects.filter(
+        data__project=project,
+        data__queues__type='admin'
+    )
+
+    data_labels = {}
+
+    for log in irr_logs:
+        data_id = log.data_id
+        username = log.profile.user.username
+        label = log.label.name
+
+        if data_id not in data_labels:
+            data_labels[data_id] = {"data_id": data_id} 
+        data_labels[data_id][username] = label
+
+    response_data = list(data_labels.values())
+
+    return Response({"data": response_data})
+
+
 
 @api_view(["GET"])
 @permission_classes((IsAdminOrCreator,))

--- a/frontend/src/actions/adminTables.js
+++ b/frontend/src/actions/adminTables.js
@@ -11,10 +11,12 @@ import { queryClient } from "../store";
 export const SET_ADMIN_DATA = 'SET_ADMIN_DATA';
 export const SET_DISCARDED_DATA = 'SET_DISCARDED_DATA';
 export const SET_ADMIN_COUNTS = 'SET_ADMIN_COUNTS';
+export const SET_IRR_LOG = 'SET_IRR_LOG';
 
 export const set_admin_data = createAction(SET_ADMIN_DATA);
 export const set_discarded_data = createAction(SET_DISCARDED_DATA);
 export const set_admin_counts = createAction(SET_ADMIN_COUNTS);
+export const set_irr_log = createAction(SET_IRR_LOG);
 
 
 //get the skipped data for the admin Table
@@ -49,6 +51,29 @@ export const getAdmin = (projectID) => {
                 dispatch(set_admin_data(all_data));
             })
             .catch(err => console.log("Error: ", err));
+    };
+};
+
+export const getIrrLog = (projectID) => {
+    let apiURL = `/api/irr_log/${projectID}/`;
+    return dispatch => {
+        return fetch(apiURL, getConfig())
+            .then(response => {
+                if (response.ok) {
+                    return response.json();
+                } else {
+                    const error = new Error(response.statusText);
+                    error.response = response;
+                    throw error;
+                }
+            })
+            .then(response => {
+                if ('error' in response) {
+                    return dispatch(setMessage(response.error));
+                } else {
+                    dispatch(set_irr_log(response.data));
+                }
+            });
     };
 };
 

--- a/frontend/src/actions/adminTables.js
+++ b/frontend/src/actions/adminTables.js
@@ -54,8 +54,11 @@ export const getAdmin = (projectID) => {
     };
 };
 
-export const getIrrLog = (projectID) => {
+export const getIrrLog = (projectID, adminOnly = false) => {
     let apiURL = `/api/irr_log/${projectID}/`;
+
+    if (adminOnly) apiURL += '?admin=true';
+
     return dispatch => {
         return fetch(apiURL, getConfig())
             .then(response => {
@@ -71,7 +74,7 @@ export const getIrrLog = (projectID) => {
                 if ('error' in response) {
                     return dispatch(setMessage(response.error));
                 } else {
-                    dispatch(set_irr_log(response.data));
+                    dispatch(set_irr_log(response.irr_log));
                 }
             });
     };

--- a/frontend/src/components/AdminTable/IRRtable.jsx
+++ b/frontend/src/components/AdminTable/IRRtable.jsx
@@ -5,7 +5,6 @@ const IRRtable = ({ irrEntry }) => {
     if (!irrEntry || !Object.keys(irrEntry).length){
         return <Fragment>Error loading IRR data</Fragment>;
     }
-    const { data_id, ...irrData } = irrEntry;
     return (
         <Card className="irr-card d-flex flex-column m-0 p-3" >
             <Table striped bordered hover>
@@ -13,13 +12,15 @@ const IRRtable = ({ irrEntry }) => {
                     <tr>
                         <th>User</th>
                         <th>Label</th>
+                        <th>Description</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {Object.entries(irrData).map(([user, label], index) => (
+                    {Object.entries(irrEntry).map(([user, label], index) => (
                         <tr key={index}>
                             <td style={{ wordWrap: "break-word", whiteSpace: "normal" }}>{user}</td>
-                            <td style={{ wordWrap: "break-word", whiteSpace: "normal" }}>{label}</td>
+                            <td style={{ wordWrap: "break-word", whiteSpace: "normal" }}>{label.name}</td>
+                            <td style={{ wordWrap: "break-word", whiteSpace: "normal" }}>{label.description}</td>
                         </tr>
                     ))}
                 </tbody>

--- a/frontend/src/components/AdminTable/IRRtable.jsx
+++ b/frontend/src/components/AdminTable/IRRtable.jsx
@@ -1,0 +1,31 @@
+import React, { Fragment } from "react";
+import { Card, Table } from "react-bootstrap";
+
+const IRRtable = ({ irrEntry }) => {
+    if (!irrEntry || !Object.keys(irrEntry).length){
+        return <Fragment>Error loading IRR data</Fragment>;
+    }
+    const { data_id, ...irrData } = irrEntry;
+    return (
+        <Card className="irr-card d-flex flex-column m-0 p-3" >
+            <Table striped bordered hover>
+                <thead>
+                    <tr>
+                        <th>User</th>
+                        <th>Label</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {Object.entries(irrData).map(([user, label], index) => (
+                        <tr key={index}>
+                            <td style={{ wordWrap: "break-word", whiteSpace: "normal" }}>{user}</td>
+                            <td style={{ wordWrap: "break-word", whiteSpace: "normal" }}>{label}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </Table>
+        </Card>
+    );
+};
+
+export default IRRtable;

--- a/frontend/src/components/AdminTable/index.jsx
+++ b/frontend/src/components/AdminTable/index.jsx
@@ -31,16 +31,16 @@ class AdminTable extends React.Component {
         const { admin_data, irr_log, labels, message, adminLabel, discardData } = this.props;
 
         const getIrrEntry = data_id => {
-            const irr_entry = irr_log.find(entry => entry.data_id === data_id);
+            const relevant_irr_entries = irr_log.filter(entry => entry.data === data_id);
             const irr_entry_formatted = {};
-            for (let user in irr_entry) {
-                if (user === "data_id") continue;
-                const label_id = irr_entry[user];
+            for (let entry of relevant_irr_entries) {
+                const username = entry.profile;
+                const label_id = entry.label;
                 if (!label_id) {
                     // situation where the irr data was adjudicated instead of labeled
-                    irr_entry_formatted[user] = { name: "", description: "" };
+                    irr_entry_formatted[username] = { name: "", description: "" };
                 } else {
-                    irr_entry_formatted[user] = labels.find(label => label.pk === label_id);
+                    irr_entry_formatted[username] = labels.find(label => label.pk === label_id);
                 }
             }
             return irr_entry_formatted;

--- a/frontend/src/components/AdminTable/index.jsx
+++ b/frontend/src/components/AdminTable/index.jsx
@@ -32,8 +32,18 @@ class AdminTable extends React.Component {
 
         const getIrrEntry = data_id => {
             const irr_entry = irr_log.find(entry => entry.data_id === data_id);
-            if (irr_entry) return irr_entry;
-            return {};
+            const irr_entry_formatted = {};
+            for (let user in irr_entry) {
+                if (user === "data_id") continue;
+                const label_id = irr_entry[user];
+                if (!label_id) {
+                    // situation where the irr data was adjudicated instead of labeled
+                    irr_entry_formatted[user] = { name: "", description: "" };
+                } else {
+                    irr_entry_formatted[user] = labels.find(label => label.pk === label_id);
+                }
+            }
+            return irr_entry_formatted;
         };
 
         const columns = [
@@ -71,7 +81,7 @@ class AdminTable extends React.Component {
                                     page={PAGES.ADMIN} 
                                     actions={{ onSelectLabel: adminLabel, onDiscard: discardData }} 
                                 />
-                                { row.original.reason === "IRR" &&
+                                { row.original.reason === "IRR" && irr_log.length &&
                                     <IRRtable irrEntry={getIrrEntry(row.original.id)} />
                                 }
                             </div>

--- a/frontend/src/components/AdminTable/index.jsx
+++ b/frontend/src/components/AdminTable/index.jsx
@@ -3,10 +3,12 @@ import PropTypes from "prop-types";
 import ReactTable from "react-table-6";
 import CodebookLabelMenuContainer from "../../containers/codebookLabelMenu_container";
 import DataCard, { PAGES } from "../DataCard/DataCard";
+import IRRtable from "./IRRtable";
 
 class AdminTable extends React.Component {
     componentDidMount() {
         this.props.getAdmin();
+        this.props.getIrrLog();
     }
 
     getText(row) {
@@ -26,7 +28,13 @@ class AdminTable extends React.Component {
     }
 
     render() {
-        const { admin_data, labels, message, adminLabel, discardData } = this.props;
+        const { admin_data, irr_log, labels, message, adminLabel, discardData } = this.props;
+
+        const getIrrEntry = data_id => {
+            const irr_entry = irr_log.find(entry => entry.data_id === data_id);
+            if (irr_entry) return irr_entry;
+            return {};
+        };
 
         const columns = [
             {
@@ -57,15 +65,22 @@ class AdminTable extends React.Component {
                                     <p style={{ whiteSpace: "normal" }}>{row.original.message}</p>
                                 </div>
                             )}
-                            <DataCard 
-                                data={row.original}
-                                page={PAGES.ADMIN} 
-                                actions={{ onSelectLabel: adminLabel, onDiscard: discardData }} 
-                            /> 
+                            <div className="admin-data-card-wrapper">                            
+                                <DataCard 
+                                    data={row.original}
+                                    page={PAGES.ADMIN} 
+                                    actions={{ onSelectLabel: adminLabel, onDiscard: discardData }} 
+                                />
+                                { row.original.reason === "IRR" &&
+                                    <IRRtable irrEntry={getIrrEntry(row.original.id)} />
+                                }
+                            </div>
                         </div>
                     );
                 }
-            }
+            },
+            // column for coder, label table
+            
         ];
 
         let page_sizes = [1];

--- a/frontend/src/containers/adminTable_container.jsx
+++ b/frontend/src/containers/adminTable_container.jsx
@@ -27,7 +27,7 @@ const mapDispatchToProps = (dispatch) => {
             dispatch(getAdmin(PROJECT_ID));
         },
         getIrrLog: () => {
-            dispatch(getIrrLog(PROJECT_ID));
+            dispatch(getIrrLog(PROJECT_ID, true));
         },
         discardData: (dataID) => {
             dispatch(discardData(dataID, PROJECT_ID));

--- a/frontend/src/containers/adminTable_container.jsx
+++ b/frontend/src/containers/adminTable_container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { adminLabel, getAdmin, discardData } from '../actions/adminTables';
+import { adminLabel, getAdmin, getIrrLog, discardData } from '../actions/adminTables';
 import AdminTable from '../components/AdminTable';
 
 const PROJECT_ID = window.PROJECT_ID;
@@ -11,6 +11,7 @@ const AdminTableContainer = (props) => <AdminTable {...props} />;
 const mapStateToProps = (state) => {
     return {
         admin_data: state.adminTables.admin_data,
+        irr_log: state.adminTables.irr_log,
         labels: state.smart.labels,
         message: state.card.message,
         admin_counts: state.adminTables.admin_counts
@@ -24,6 +25,9 @@ const mapDispatchToProps = (dispatch) => {
         },
         getAdmin: () => {
             dispatch(getAdmin(PROJECT_ID));
+        },
+        getIrrLog: () => {
+            dispatch(getIrrLog(PROJECT_ID));
         },
         discardData: (dataID) => {
             dispatch(discardData(dataID, PROJECT_ID));

--- a/frontend/src/reducers/adminTables.js
+++ b/frontend/src/reducers/adminTables.js
@@ -1,16 +1,20 @@
 import { handleActions } from 'redux-actions';
 import update from 'immutability-helper';
 
-import { SET_ADMIN_DATA, SET_ADMIN_COUNTS } from '../actions/adminTables';
+import { SET_ADMIN_DATA, SET_ADMIN_COUNTS, SET_IRR_LOG } from '../actions/adminTables';
 
 const initialState = {
     admin_data: [],
-    admin_counts: []
+    admin_counts: [],
+    irr_log: []
 };
 
 const adminTables = handleActions({
     [SET_ADMIN_DATA]: (state, action) => {
         return update(state, { admin_data: { $set: action.payload } } );
+    },
+    [SET_IRR_LOG]: (state, action) => {
+        return update(state, { irr_log: { $set: action.payload } } );
     },
     [SET_ADMIN_COUNTS]: (state, action) => {
         return update(state, { admin_counts: { $set: action.payload } } );

--- a/frontend/src/styles/smart.scss
+++ b/frontend/src/styles/smart.scss
@@ -751,3 +751,21 @@ li.disabled {
         margin-right: 5px;
     }
 }
+
+.admin-data-card-wrapper {
+    display: flex;
+
+    > :first-child {
+        flex-grow: 1;
+        display: block !important;
+    }
+
+    .irr-card {
+        width: 425px;
+        overflow-x: scroll
+    }
+  
+    .btn-toolbar {
+        display: block;
+    }
+}

--- a/frontend/src/styles/smart.scss
+++ b/frontend/src/styles/smart.scss
@@ -761,7 +761,7 @@ li.disabled {
     }
 
     .irr-card {
-        width: 425px;
+        width: 450px;
         overflow-x: scroll
     }
   

--- a/frontend/src/styles/smart.scss
+++ b/frontend/src/styles/smart.scss
@@ -758,6 +758,10 @@ li.disabled {
     > :first-child {
         flex-grow: 1;
         display: block !important;
+
+        p {
+            max-width: 500px;
+        }
     }
 
     .irr-card {


### PR DESCRIPTION
- created a new endpoint to retrieve the irr log entries that also appear in the admin queue
- the adjudication tab pulls from this endpoint and displays a table each user's labels for IRR disagreements