### PR TITLE
Add type column to history table

### DIFF
--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -1038,9 +1038,9 @@ def get_label_history(request, project_pk):
 
     data_types_dict = {}
     for pk in total_data_list:
-        data_types_dict[pk] = "labeled"
+        data_types_dict[pk] = "Labeled"
     for pk in unlabeled_data_list:
-        data_types_dict[pk] = "unlabeled"
+        data_types_dict[pk] = "Unlabeled"
     for pk in incomplete_irr_data:
         data_types_dict[pk] = "IRR Incomplete"
     for pk in pending_irr_data:

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -1193,6 +1193,7 @@ def get_label_history(request, project_pk):
         # User's can't edit Incomplete IRR that isn't their own, even admin. Profile will be na because of left join above.
         data_df.loc[(data_df["type"] == "IRR Incomplete"), "edit"] = "Yes"
         data_df.loc[(data_df["type"] == "IRR Incomplete") & (data_df["profile"].isna()), "edit"] = "No"
+        data_df.loc[(data_df["type"] == "IRR Pending") & (data_df["profile"].isna()), "edit"] = "No"
     else:
         data_df["edit"] = "Yes"
         data_df["label"] = ""

--- a/frontend/src/components/History/HistoryTable.jsx
+++ b/frontend/src/components/History/HistoryTable.jsx
@@ -50,6 +50,13 @@ const defaultColumns = {
             sortingFn: "alphanumeric"
         },
         {
+            accessorKey: "type",
+            filterFn: "includesString",
+            header: "Type",
+            id: "Type",
+            sortingFn: "alphanumeric"
+        },
+        {
             accessorKey: "profile",
             filterFn: "includesString",
             header: "Labeled By",

--- a/frontend/src/components/History/HistoryTable.jsx
+++ b/frontend/src/components/History/HistoryTable.jsx
@@ -35,6 +35,13 @@ const defaultColumns = {
             id: "Expander"
         },
         {
+            accessorKey: "type",
+            filterFn: "includesString",
+            header: "Type",
+            id: "Type",
+            sortingFn: "alphanumeric"
+        },
+        {
             accessorKey: "data",
             filterFn: "includesString",
             header: "Data",
@@ -47,13 +54,6 @@ const defaultColumns = {
             filterFn: "includesString",
             header: "Label",
             id: "Current Label",
-            sortingFn: "alphanumeric"
-        },
-        {
-            accessorKey: "type",
-            filterFn: "includesString",
-            header: "Type",
-            id: "Type",
             sortingFn: "alphanumeric"
         },
         {


### PR DESCRIPTION
Implemented logic for type column in history table. The possible types are
- Labeled
- Unlabeled
- IRR Incomplete
- IRR Pending
- IRR Finalized
- IRR Historic


Currently the "Type" column is text - I believe we'll want to change that to icons before merging. 