### PR TITLE
Fix bug causing projects with > 100 labels to break

### DIFF
--- a/backend/django/core/serializers.py
+++ b/backend/django/core/serializers.py
@@ -102,13 +102,21 @@ class DataLabelSerializer(serializers.HyperlinkedModelSerializer):
 
 class IRRLogModelSerializer(serializers.ModelSerializer):
     profile = serializers.StringRelatedField(many=False, read_only=True)
+    label_name = serializers.SerializerMethodField()
+    label_description = serializers.SerializerMethodField()
     timestamp = serializers.DateTimeField(
         default_timezone=pytz.timezone(TIME_ZONE_FRONTEND), format="%Y-%m-%d, %I:%M %p"
     )
 
     class Meta:
         model = IRRLog
-        fields = ("data", "profile", "label", "timestamp")
+        fields = ("data", "profile", "label", "label_name", "label_description", "timestamp")
+    
+    def get_label_name(self, obj):
+        return obj.label.name if obj.label else None
+
+    def get_label_description(self, obj):
+        return obj.label.description if obj.label else None
 
 
 class IRRLog(serializers.HyperlinkedModelSerializer):

--- a/frontend/src/components/AdminTable/index.jsx
+++ b/frontend/src/components/AdminTable/index.jsx
@@ -142,7 +142,6 @@ class AdminTable extends React.Component {
 AdminTable.propTypes = {
     getAdmin: PropTypes.func.isRequired,
     admin_data: PropTypes.arrayOf(PropTypes.object),
-    labels: PropTypes.arrayOf(PropTypes.object),
     message: PropTypes.string,
     adminLabel: PropTypes.func.isRequired,
     discardData: PropTypes.func.isRequired

--- a/frontend/src/components/AdminTable/index.jsx
+++ b/frontend/src/components/AdminTable/index.jsx
@@ -28,19 +28,18 @@ class AdminTable extends React.Component {
     }
 
     render() {
-        const { admin_data, irr_log, labels, message, adminLabel, discardData } = this.props;
+        const { admin_data, irr_log, message, adminLabel, discardData } = this.props;
 
         const getIrrEntry = data_id => {
             const relevant_irr_entries = irr_log.filter(entry => entry.data === data_id);
             const irr_entry_formatted = {};
             for (let entry of relevant_irr_entries) {
                 const username = entry.profile;
-                const label_id = entry.label;
-                if (!label_id) {
+                if (entry.label === null) {
                     // situation where the irr data was adjudicated instead of labeled
                     irr_entry_formatted[username] = { name: "", description: "" };
                 } else {
-                    irr_entry_formatted[username] = labels.find(label => label.pk === label_id);
+                    irr_entry_formatted[username] = { name: entry.label_name, description: entry.label_description };
                 }
             }
             return irr_entry_formatted;

--- a/frontend/src/containers/adminTable_container.jsx
+++ b/frontend/src/containers/adminTable_container.jsx
@@ -12,7 +12,6 @@ const mapStateToProps = (state) => {
     return {
         admin_data: state.adminTables.admin_data,
         irr_log: state.adminTables.irr_log,
-        labels: state.smart.labels,
         message: state.card.message,
         admin_counts: state.adminTables.admin_counts
     };


### PR DESCRIPTION
Previously the IRR tables were relying on the `get_labels` endpoint to retrieve label names to join to the ids. With this update, we include the label names in the IRR endpoint so no need to call `get_labels`.