### PR TITLE
Fix outdated docker volume instructions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ setup:
   stage: setup
   script:
     - cd envs/dev
-    - docker volume create vol_smart_pgdata && docker volume create vol_smart_data
+    - docker volume create vol_smart_pgdata_15_2 && docker volume create vol_smart_data
     - docker-compose up -d
   after_script:
     - cd envs/dev
@@ -54,6 +54,6 @@ cleanup:
   script:
     - cd envs/dev
     - docker-compose down
-    - docker volume remove vol_smart_pgdata
+    - docker volume remove vol_smart_pgdata_15_2
     - docker volume remove vol_smart_data
   when: always

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker-compose build
 Next, create the docker volumes where persistent data will be stored.
 
 ```bash
-docker volume create --name=vol_smart_pgdata
+docker volume create --name=vol_smart_pgdata_15_2
 docker volume create --name=vol_smart_data
 ```
 

--- a/smart-docs/docs/index.rst
+++ b/smart-docs/docs/index.rst
@@ -19,7 +19,7 @@ Quick Start
 	$ git clone https://github.com/RTIInternational/SMART.git
 	$ cd smart/envs/dev/
 	$ docker-compose build
-	$ docker volume create --name=vol_smart_pgdata
+	$ docker volume create --name=vol_smart_pgdata_15_2
 	$ docker volume create --name=vol_smart_data
   $ docker-compose run --rm backend ./migrate.sh
 	$ docker-compose up -d

--- a/smart-docs/docs/tutorial-installation.rst
+++ b/smart-docs/docs/tutorial-installation.rst
@@ -17,11 +17,11 @@ SMART uses Docker in development to aid in dependency management. First, install
 	$ cd smart/envs/dev
 	$ docker-compose build
 
-Next, create the docker volumes where persistent data will be stored: ``docker volume create --name=vol_smart_pgdata`` and ``docker volume create --name=vol_smart_data``.
+Next, create the docker volumes where persistent data will be stored: ``docker volume create --name=vol_smart_pgdata_15_2`` and ``docker volume create --name=vol_smart_data``.
 
 ::
 
-	$ docker volume create --name=vol_smart_pgdata
+	$ docker volume create --name=vol_smart_pgdata_15_2
 	$ docker volume create --name=vol_smart_data
 
 Then, migrate the database to ensure the schema is prepared for the application.


### PR DESCRIPTION
Hi - I was following the setup installation docs and found a docker volume name was outdated.

This PR updates the postgres docker volume name from `pgdata` to `pgdata_15_2` (also see https://github.com/RTIInternational/SMART/issues/317).
