### PR TITLE
Prevent history table from truncating rows at 100

### DIFF
--- a/frontend/src/components/History/HistoryTable.jsx
+++ b/frontend/src/components/History/HistoryTable.jsx
@@ -427,12 +427,12 @@ const HistoryTable = () => {
                     ))}
                 </thead>
                 <tbody>
-                    {table.getRowModel().rows.map((row, index) => (
+                    {table.getRowModel().rows.map(row => (
                         <Fragment key={row.id}>
                             <tr>
                                 {row.getVisibleCells().map(cell => (
                                     <td className="align-middle" key={cell.id}>
-                                        { index }{flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
                                     </td>
                                 ))}
                             </tr>

--- a/frontend/src/components/History/HistoryTable.jsx
+++ b/frontend/src/components/History/HistoryTable.jsx
@@ -244,8 +244,10 @@ const HistoryTable = () => {
         getSortedRowModel: getSortedRowModel(),
         initialState: {
             pagination: {
-                pageSize: 100
-            }
+                // setting arbitrary high number to avoid items being cut off
+                // actual page size is driven by data length
+                pageSize: 10000,
+            },
         },
         pageCount: historyData ? historyData.total_pages : 1,
         onColumnVisibilityChange: setColumnVisibility,
@@ -425,12 +427,12 @@ const HistoryTable = () => {
                     ))}
                 </thead>
                 <tbody>
-                    {table.getRowModel().rows.map(row => (
+                    {table.getRowModel().rows.map((row, index) => (
                         <Fragment key={row.id}>
                             <tr>
                                 {row.getVisibleCells().map(cell => (
                                     <td className="align-middle" key={cell.id}>
-                                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                        { index }{flexRender(cell.column.columnDef.cell, cell.getContext())}
                                     </td>
                                 ))}
                             </tr>


### PR DESCRIPTION
With the new IRR logic, sometimes over 100 rows get returned for each history page. Previously, the History Table frontend was configured to cap rows at 100. This PR updates the config allowing it to render all rows for page.