### PR TITLE
add a whole bunch of category fixes

### DIFF
--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -155,9 +155,11 @@ class ProjectUpdateAdvancedForm(forms.ModelForm):
         else:
             start_val = "None"
         data_metadata = project.metadatafields.values_list("field_name", flat=True)
+        data_metadata = [m.lower().capitalize() for m in data_metadata]
         label_metadata = project.labelmetadatafields.values_list(
             "field_name", flat=True
         )
+        label_metadata = [lm.lower().capitalize() for lm in label_metadata]
         options = list(set(data_metadata) & set(label_metadata)) + ["None"]
 
         percentage_irr = kwargs.pop("percentage_irr")

--- a/backend/django/core/models.py
+++ b/backend/django/core/models.py
@@ -108,6 +108,12 @@ class Project(models.Model):
     def labeled_data_count(self):
         return self.data_set.all().filter(datalabel__isnull=False).count()
 
+    def first_100_labels(self):
+        if self.labels.count() > 100:
+            return self.labels.all()[:100]
+        else:
+            return self.labels.all()
+
     def unverified_labeled_data_count(self):
         return (
             self.data_set.all()
@@ -430,6 +436,8 @@ class LabelMetaData(models.Model):
     value = models.TextField(null=True, blank=True)
 
     def __str__(self):
+        if str(self.value) == "nan":
+            return ""
         return f"{str(self.label_metadata_field)}: {self.value}"
 
 

--- a/backend/django/core/serializers.py
+++ b/backend/django/core/serializers.py
@@ -61,11 +61,14 @@ class LabelSerializer(serializers.ModelSerializer):
 
     def to_representation(self, obj):
         base_representation = super().to_representation(obj)
-        if len(base_representation["labelmetadata"]) > 0:
+        if str(base_representation["description"]) == "nan":
+            base_representation["description"] = ""
+
+        metadata = [m for m in base_representation["labelmetadata"] if str(m) != ""]
+
+        if len(metadata) > 0:
             base_representation["description"] = (
-                base_representation["description"]
-                + " | "
-                + " | ".join(base_representation["labelmetadata"])
+                base_representation["description"] + " | " + " | ".join(metadata)
             )
         return base_representation
 

--- a/backend/django/core/templates/projects/create/create_wizard_advanced.html
+++ b/backend/django/core/templates/projects/create/create_wizard_advanced.html
@@ -11,12 +11,18 @@
 {% endblock %}
 
 {% block content %}
+<div class="overlay">
+  <div class="overlay_contents">
+      <div id="second_progress"></div>
+      <span id="loading_text"></span>
+  </div>
+</div>
 <div class="error-messages">{{ wizard.non_form_errors }}</div>
 <div class="row">
   <div class="col-md-8 col-md-offset-2">
     <div class="card">
       <div class="cardface">
-        <form action="." method="post" enctype="multipart/form-data">
+        <form action="." method="post" enctype="multipart/form-data" onsubmit="addASpinner()">
           {% csrf_token %}
           {{ wizard.management_form }}
 
@@ -262,5 +268,14 @@ $('input#id_advanced-allow_coders_view_labels').change(function() {
     irr_or_not_box_disabled.hide();
   }
 });
+
+function addASpinner() {
+        $('.overlay').show();
+        $('#loading_text').html("Please wait. Creating project...");
+        $("#second_progress").addClass("loader");
+        setTimeout(function() {
+            $('#loading_text').html("Still processing data...");
+        }, 30000)
+    }
 </script>
 {% endblock %}

--- a/backend/django/core/templates/projects/create/create_wizard_labels.html
+++ b/backend/django/core/templates/projects/create/create_wizard_labels.html
@@ -22,7 +22,7 @@
   <div class="col-md-8 col-md-offset-2">
     <div class="card">
       <div class="cardface">
-        <form action="." method="post" enctype="multipart/form-data">
+        <form action="." method="post" enctype="multipart/form-data" onsubmit="addASpinner()">
           {% csrf_token %}
           {{ wizard.management_form }}
 
@@ -61,5 +61,15 @@
 {% endblock %}
 
 {% block scripts_body %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-csv/0.71/jquery.csv-0.71.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-csv/0.71/jquery.csv-0.71.min.js">
+  function addASpinner() {
+        $('.overlay').show();
+        $('#loading_text').html("Please wait. Updating labels...");
+        $("#second_progress").addClass("loader");
+        //after 30 seconds, update the message
+        setTimeout(function() {
+            $('#loading_text').html("Still processing data...");
+        }, 30000)
+    }
+</script>
 {% endblock %}

--- a/backend/django/core/templates/projects/create/create_wizard_labels.html
+++ b/backend/django/core/templates/projects/create/create_wizard_labels.html
@@ -61,7 +61,7 @@
 {% endblock %}
 
 {% block scripts_body %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-csv/0.71/jquery.csv-0.71.min.js">
+<script>
   function addASpinner() {
         $('.overlay').show();
         $('#loading_text').html("Please wait. Updating labels...");

--- a/backend/django/core/templates/projects/detail.html
+++ b/backend/django/core/templates/projects/detail.html
@@ -168,7 +168,7 @@
                 <li class="list-group-item">
                   <dt>Metadata Fields Displayed with Data</dt>
                   {% for meta in project.metadatafields.all %}
-                      {% if meta.field_name == project.category.field_name %}
+                      {% if meta.field_name.lower == project.category.field_name.lower %}
                         <dd>- [CATEGORY] {{ meta.field_name }} </dd>
                       {% else %}
                         <dd>- {{ meta.field_name }}</dd>
@@ -180,7 +180,7 @@
                 <li class="list-group-item">
                   <dt>Metadata Fields Displayed with Labels</dt>
                   {% for meta in project.labelmetadatafields.all %}
-                    {% if meta.field_name == project.category.field_name %}
+                    {% if meta.field_name.lower == project.category.field_name.lower %}
                       <dd>- [CATEGORY] {{ meta.field_name }} </dd>
                     {% else %}
                       <dd>- {{ meta.field_name }}</dd>
@@ -217,7 +217,7 @@
           <div id="label-panel" class="panel-collapse collapse">
             <div class="panel-body">
               <ul class="list-group-flush">
-                {% for label in project.labels.all %}
+                {% for label in project.first_100_labels %}
                   <li class="list-group-item">
                     <dt>{{ label.name }}</dt>
                     <dd>{{ label.description }} {% for meta in label.labelmetadata.all %} | {{ meta }} {% endfor %}</dd>

--- a/backend/django/core/templates/projects/update/labels.html
+++ b/backend/django/core/templates/projects/update/labels.html
@@ -4,12 +4,18 @@
 {% load render_bundle from webpack_loader %}
 
 {% block content %}
+<div class="overlay">
+  <div class="overlay_contents">
+      <div id="second_progress"></div>
+      <span id="loading_text"></span>
+  </div>
+</div>
 <div class="row">
   <div class="col-md-8 col-md-offset-2">
     <div class="card">
       <div class="cardface">
         {{ form.media.css }}
-        <form action="." method="post" enctype="multipart/form-data">
+        <form action="." method="post" enctype="multipart/form-data" onsubmit="addASpinner()">
           {% csrf_token %}
           <h1>Update Label Descriptions/Metadata</h1>
           <p>This section lets you update your label descriptions or add/update metadata. Please upload a csv or excel file containing the fields 'Label', 'Description',
@@ -20,6 +26,7 @@
           <div class="form-group">
             <label class="control-label" for="{{ form.data.id_for_label }}">{{ form.data.label }}</label>
             <input class="form-control" id="{{ form.data.id_for_label }}" maxlength="30" name="{{ form.data.html_name }}" type="file" placeholder="{{ form.data.label }}" />
+            <div class="error-messages">{{ form.non_field_errors }}</div>
             <div class="error-messages">{{ form.data.errors }}</div>
             <div class="error-messages">{{ form.all.errors }}</div>
           </div>
@@ -29,4 +36,17 @@
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts_body %}
+<script type="text/javascript">
+      function addASpinner() {
+        $('.overlay').show();
+        $('#loading_text').html("Please wait. Uploading labels...");
+        $("#second_progress").addClass("loader");
+        setTimeout(function() {
+            $('#loading_text').html("STILL Processing labels...");
+        }, 30000)
+    }
+</script>
 {% endblock %}

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -895,7 +895,7 @@ def update_label_descriptions_metadata(project, new_data):
     label_metadata = [c for c in new_data if c not in ["Label", "Description"]]
     for metadata_col in label_metadata:
         label_metadata_field, created = LabelMetaDataField.objects.get_or_create(
-            project=project, field_name=metadata_col
+            project=project, field_name__iexact=metadata_col
         )
         if created:
             # create objects for each label in the entire label set

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -847,33 +847,31 @@ def create_label_metadata(project, label_data, label_list):
             )
 
 
-def create_or_update_project_category(project, label_metadata, data_metadata):
+def create_or_update_project_category(project, new_category):
     """This function takes a field which overlaps between the label and data metadata
     and sets it to the project category to filter the suggestions by."""
-    metadata_both = list(set(data_metadata) & set(label_metadata))
-    if len(metadata_both) > 0:
-        # by default just pick the first overlap
-        if Category.objects.filter(project=project).exists():
-            Category.objects.filter(project=project).update(
-                field_name=metadata_both[0],
-                label_metadata_field=LabelMetaDataField.objects.get(
-                    field_name=metadata_both[0], project=project
-                ),
-                data_metadata_field=MetaDataField.objects.get(
-                    field_name=metadata_both[0], project=project
-                ),
-            )
-        else:
-            Category.objects.create(
-                project=project,
-                field_name=metadata_both[0],
-                label_metadata_field=LabelMetaDataField.objects.get(
-                    field_name=metadata_both[0], project=project
-                ),
-                data_metadata_field=MetaDataField.objects.get(
-                    field_name=metadata_both[0], project=project
-                ),
-            )
+    # by default just pick the first overlap
+    if Category.objects.filter(project=project).exists():
+        Category.objects.filter(project=project).update(
+            field_name=new_category,
+            label_metadata_field=LabelMetaDataField.objects.get(
+                field_name__iexact=new_category, project=project
+            ),
+            data_metadata_field=MetaDataField.objects.get(
+                field_name__iexact=new_category, project=project
+            ),
+        )
+    else:
+        Category.objects.create(
+            project=project,
+            field_name=new_category,
+            label_metadata_field=LabelMetaDataField.objects.get(
+                field_name__iexact=new_category, project=project
+            ),
+            data_metadata_field=MetaDataField.objects.get(
+                field_name__iexact=new_category, project=project
+            ),
+        )
 
 
 def update_label_descriptions_metadata(project, new_data):
@@ -934,4 +932,9 @@ def update_label_descriptions_metadata(project, new_data):
     data_metadata = MetaDataField.objects.filter(project=project).values_list(
         "field_name", flat=True
     )
-    create_or_update_project_category(project, label_metadata, data_metadata)
+    metadata_both = list(
+        set([m.lower() for m in data_metadata])
+        & set([m.lower() for m in label_metadata])
+    )
+    if len(metadata_both) > 0:
+        create_or_update_project_category(project, metadata_both[0])

--- a/backend/django/core/utils/utils_form.py
+++ b/backend/django/core/utils/utils_form.py
@@ -23,6 +23,13 @@ def clean_data_helper(
     if len(data) < 1:
         raise ValidationError("Data is empty.")
 
+    lower_cols = [c.lower() for c in data.columns]
+    if len(lower_cols) > len(set(lower_cols)):
+        raise ValidationError(
+            "There are duplicate fields in this file. To avoid confusion "
+            "SMART requires all fields to have unique names."
+        )
+
     found_metadata_fields = [
         c for c in data.columns if c not in ["Text", "Label", "ID"]
     ]
@@ -106,8 +113,15 @@ def clean_label_data_helper(data, existing_labels=[]):
             f"New labels were found in this file: {', '.join(new_labels)}"
         )
 
-    if len(data) < 2:
+    if len(data) < 2 and len(existing_labels) == 0:
         raise ValidationError("At least two labels are required.")
+
+    lower_cols = [c.lower() for c in data.columns]
+    if len(lower_cols) > len(set(lower_cols)):
+        raise ValidationError(
+            "There are duplicate fields in this file. To avoid confusion "
+            "SMART requires all fields to have unique names."
+        )
 
     if len(data["Label"].unique()) < len(data):
         label_counts = data["Label"].value_counts()

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -79,11 +79,17 @@ class SearchLabelsView(ListAPIView):
         filter_text = self.request.GET.get("searchString")
 
         label_category = self.request.GET.get("category")
-        if label_category:
-            category_label_list = LabelMetaData.objects.filter(
-                label_metadata_field=project.category.label_metadata_field,
-                value=label_category,
-            ).values_list("label__pk", flat=True)
+        if label_category and label_category != "all":
+            if label_category == "None":
+                category_label_list = LabelMetaData.objects.filter(
+                    label_metadata_field=project.category.label_metadata_field,
+                    value="nan",
+                ).values_list("label__pk", flat=True)
+            else:
+                category_label_list = LabelMetaData.objects.filter(
+                    label_metadata_field=project.category.label_metadata_field,
+                    value=label_category,
+                ).values_list("label__pk", flat=True)
             return Label.objects.filter(
                 project=project, pk__in=category_label_list
             ).filter(
@@ -120,12 +126,15 @@ def get_label_categories(request, project_pk, data_pk):
                 metadata_field=data_metadata_field, data=data_options
             ).value
             if data_category not in category_options:
-                data_category = ""
+                data_category = "all"
         else:
-            data_category = ""
+            data_category = "all"
+
+        category_options = [c if str(c) != "nan" else "None" for c in category_options]
         return Response(
             {
-                "label_category_options": [
+                "label_category_options": [{"value": "all", "label": "Category: all"}]
+                + [
                     {"value": key, "label": f"Category: {key}"}
                     for key in category_options
                 ],
@@ -150,9 +159,10 @@ def get_labels(request, project_pk):
     total_labels = Label.objects.filter(project=project).count()
 
     # If the number of labels is > 100, just return the first 100
-    serialized_labels = LabelSerializer(labels, many=True).data
-    if len(serialized_labels) > 100:
-        serialized_labels = serialized_labels[:100]
+    if total_labels < 100:
+        serialized_labels = LabelSerializer(labels, many=True).data
+    else:
+        serialized_labels = []
 
     return Response({"labels": serialized_labels, "total_labels": total_labels})
 
@@ -380,6 +390,13 @@ def annotate_data(request, data_pk):
             "ERROR: this card was no longer assigned. Either "
             "your cards were un-assigned by an administrator or the label was clicked twice. "
             "Please refresh the page to get new assigned items to annotate."
+        )
+        return Response(response)
+
+    if not data.irr_ind and DataLabel.objects.filter(data=data).exists():
+        response["error"] = (
+            "ERROR: this card has been labeled by someone else in another tab."
+            "Please refresh the page to get new items to annotate."
         )
         return Response(response)
 
@@ -719,6 +736,7 @@ def data_unlabeled_table(request, project_pk):
         for d in serialized_data
     ]
     return Response({"data": data})
+
 
 @api_view(["POST"])
 @permission_classes([AllowAny])

--- a/frontend/src/components/DataCard/DataCard.jsx
+++ b/frontend/src/components/DataCard/DataCard.jsx
@@ -42,7 +42,7 @@ const DataCard = ({ data, page, actions }) => {
 
     const handlers = getHandlers(allHandlers, page);
 
-    const labelCountLow = (labels) => labels.labels.length <= 5;
+    const labelCountLow = (labels) => labels.total_labels <= 5;
     const labelCountHigh = (labels) => labels.total_labels >= PROJECT_SUGGESTION_MAX;
     const labelCategory = (labelCategoryOptions) => (labelCategoryOptions != null) && (labelCategoryOptions.label_category_options != null);
 

--- a/frontend/src/containers/codebookLabelMenu_container.jsx
+++ b/frontend/src/containers/codebookLabelMenu_container.jsx
@@ -3,7 +3,16 @@ import { connect } from 'react-redux';
 
 import CodebookLabelMenu from '../components/CodebookLabelMenu';
 
-const CodebookLabelMenuContainer = (props) => <CodebookLabelMenu {...props} />;
+const CODEBOOK_URL = window.CODEBOOK_URL;
+
+const CodebookLabelMenuContainer = (props) => {
+    if (CODEBOOK_URL != "") {
+        return (<CodebookLabelMenu {...props} />);
+    } else {
+        return (<div></div>);
+    }
+
+};
 
 const mapStateToProps = (state) => {
     return {};


### PR DESCRIPTION
This MR pulls together a whole bunch of little updates, mostly related to the recent category update:

* moves the label serializer code to only run in get_labels if labels < 100
* makes the category case-insensitive, so that the metadata fields with different capitalization in their name can be matched
* adds loading spinners to the label upload page and the project creation page to avoid confusion
* BUG FIX: closes a loophole in the annotate_data function so that if someone just labeled the item in the history table it won't make a second label
* slightly modifies the codebook rendering to not run a bunch of the slower code when there is no codebook
* adds an "all" category to the label category dropdown so that someone can search all labels if needed
* fixes the null description/metadata rendering so that they just aren't shown instead of having "nan" everywhere