### PR TITLE
Fixes metadata and skew

### DIFF
--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -341,6 +341,7 @@ class DataWizardForm(forms.ModelForm):
         self.cleaned_data["data"] = clean_data_helper(
             data_df, labels, dedup_on, dedup_fields
         )
+
         return self.cleaned_data
 
 

--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -46,19 +46,33 @@ def read_data_file(data_file):
 
     try:
         if data_file.content_type == "text/tab-separated-values":
-            data = pd.read_csv(data_file, sep="\t", encoding="utf-8").dropna(
-                axis=0, how="all"
-            )
+            data = pd.read_csv(
+                data_file,
+                sep="\t",
+                encoding="utf-8",
+                dtype=str,
+            ).dropna(axis=0, how="all")
         elif data_file.content_type == "text/csv":
-            data = pd.read_csv(data_file, encoding="utf-8").dropna(axis=0, how="all")
+            data = pd.read_csv(
+                data_file,
+                encoding="utf-8",
+                dtype=str,
+            ).dropna(axis=0, how="all")
         elif data_file.content_type.startswith(
             "application/vnd"
         ) and data_file.name.endswith(".csv"):
-            data = pd.read_csv(data_file, encoding="utf-8").dropna(axis=0, how="all")
+            data = pd.read_csv(
+                data_file,
+                encoding="utf-8",
+                dtype=str,
+            ).dropna(axis=0, how="all")
         elif data_file.content_type.startswith(
             "application/vnd"
         ) and data_file.name.endswith(".xlsx"):
-            data = pd.read_excel(data_file, dtype=str).dropna(axis=0, how="all")
+            data = pd.read_excel(
+                data_file,
+                dtype=str,
+            ).dropna(axis=0, how="all")
         else:
             raise ValidationError(
                 "File type is not supported.  Received {0} but only {1} are supported.".format(
@@ -75,6 +89,7 @@ def read_data_file(data_file):
         raise ValidationError(
             "Unable to read the file.  Please ensure that the file is encoded in UTF-8."
         )
+
     return data
 
 

--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -46,28 +46,19 @@ def read_data_file(data_file):
 
     try:
         if data_file.content_type == "text/tab-separated-values":
-            data = pd.read_csv(
-                data_file,
-                sep="\t",
-                encoding="utf-8"
-            ).dropna(axis=0, how="all")
+            data = pd.read_csv(data_file, sep="\t", encoding="utf-8").dropna(
+                axis=0, how="all"
+            )
         elif data_file.content_type == "text/csv":
-            data = pd.read_csv(
-                data_file, encoding="utf-8"
-            ).dropna(axis=0, how="all")
+            data = pd.read_csv(data_file, encoding="utf-8").dropna(axis=0, how="all")
         elif data_file.content_type.startswith(
             "application/vnd"
         ) and data_file.name.endswith(".csv"):
-            data = pd.read_csv(
-                data_file, encoding="utf-8"
-            ).dropna(axis=0, how="all")
+            data = pd.read_csv(data_file, encoding="utf-8").dropna(axis=0, how="all")
         elif data_file.content_type.startswith(
             "application/vnd"
         ) and data_file.name.endswith(".xlsx"):
-            data = (
-                pd.read_excel(data_file, dtype=str)
-                .dropna(axis=0, how="all")
-            )
+            data = pd.read_excel(data_file, dtype=str).dropna(axis=0, how="all")
         else:
             raise ValidationError(
                 "File type is not supported.  Received {0} but only {1} are supported.".format(

--- a/backend/django/core/forms.py
+++ b/backend/django/core/forms.py
@@ -1,5 +1,4 @@
 import copy
-from io import StringIO
 
 import pandas as pd
 from django import forms
@@ -48,21 +47,19 @@ def read_data_file(data_file):
     try:
         if data_file.content_type == "text/tab-separated-values":
             data = pd.read_csv(
-                StringIO(data_file.read().decode("utf8", "ignore")),
+                data_file,
                 sep="\t",
-                dtype=str,
+                encoding="utf-8"
             ).dropna(axis=0, how="all")
         elif data_file.content_type == "text/csv":
             data = pd.read_csv(
-                StringIO(data_file.read().decode("utf8", "ignore")),
-                dtype=str,
+                data_file, encoding="utf-8"
             ).dropna(axis=0, how="all")
         elif data_file.content_type.startswith(
             "application/vnd"
         ) and data_file.name.endswith(".csv"):
             data = pd.read_csv(
-                StringIO(data_file.read().decode("utf8", "ignore")),
-                dtype=str,
+                data_file, encoding="utf-8"
             ).dropna(axis=0, how="all")
         elif data_file.content_type.startswith(
             "application/vnd"
@@ -70,7 +67,6 @@ def read_data_file(data_file):
             data = (
                 pd.read_excel(data_file, dtype=str)
                 .dropna(axis=0, how="all")
-                .replace(r"\n", " ", regex=True)
             )
         else:
             raise ValidationError(
@@ -81,7 +77,7 @@ def read_data_file(data_file):
     except ParserError:
         # If there was an error while parsing then raise invalid file error
         raise ValidationError(
-            "Unable to read file.  Please ensure it passes all the requirments"
+            "Unable to read file.  Please ensure it passes all the requirements"
         )
     except UnicodeDecodeError:
         # Some files are not in utf-8, let's just reject those.
@@ -393,7 +389,7 @@ class LabelWizardForm(forms.Form):
                 data_file = read_data_file(data)
                 return clean_label_data_helper(data_file)
             except pd.errors.EmptyDataError:
-                return pd.DataFrame({"Label": []})
+                return None
         else:
             raise ValidationError("ERROR: no file provided")
 

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -838,7 +838,7 @@ def create_label_metadata(project, label_data):
     print(label_data)
 
     label_metadata = [
-        c for c in label_data if c not in ["Label", "Description", "label_id"]
+        c for c in label_data if c not in ["Label", "Description", "label_id", "project"]
     ]
     if len(label_metadata) > 0:
         for metadata_col in label_metadata:

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -838,7 +838,9 @@ def create_label_metadata(project, label_data):
     print(label_data)
 
     label_metadata = [
-        c for c in label_data if c not in ["Label", "Description", "label_id", "project"]
+        c
+        for c in label_data
+        if c not in ["Label", "Description", "label_id", "project"]
     ]
     if len(label_metadata) > 0:
         for metadata_col in label_metadata:

--- a/backend/django/core/utils/util.py
+++ b/backend/django/core/utils/util.py
@@ -334,9 +334,9 @@ def add_data(project, df):
 
     df["hash"] = ""
     for f in dedup_on_fields:
-        df["hash"] += df[f].astype(str) + "_"
+        df["hash"] += df[f].fillna("None").astype(str) + "_"
 
-    df["hash"] += df["Text"].astype(str)
+    df["hash"] += df["Text"].fillna("None").astype(str)
     df["hash"] = df["hash"].apply(md5_hash)
 
     df.drop_duplicates(subset=["hash"], keep="first", inplace=True)
@@ -841,18 +841,10 @@ def create_label_metadata(project, label_data):
     df_label_ids = set(label_data["Label"].tolist())
 
     need_quotes = df_label_ids - existing_label_ids
-    label_data["Label"] = label_data["Label"].apply(
-        lambda s: (
-            f'"{s}"'.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
-            if s in need_quotes
-            else s
-        )
-    )
+    label_data["Label"] = label_data["Label"].apply(lambda s: f'"{s}"'.replace('\\n', '\n').replace('\\t', '\t').replace('\\r', '\r') if s in need_quotes else s)
     df_label_ids = set(label_data["Label"].tolist())
     if len(df_label_ids - existing_label_ids) > 0:
-        raise ValidationError(
-            "ERROR loading in label metadata. Something is going wrong with the label file."
-        )
+        raise ValidationError("ERROR loading in label metadata. Something is going wrong with the label file.")
 
     label_data = label_data.merge(label_objects, on="Label", how="inner")
 

--- a/backend/django/core/utils/utils_form.py
+++ b/backend/django/core/utils/utils_form.py
@@ -115,13 +115,14 @@ def clean_label_data_helper(data, existing_labels=[]):
     new_labels = list(new_labels_all - set(existing_labels))
 
     # # try adding quotes around the "new" labels and see if they match now
-    data["Label"] = data["Label"].apply(
-        lambda s: (
-            f'"{s}"'.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
-            if s in new_labels
-            else s
+    if len(existing_labels) > 0 and len(new_labels) > 0:
+        data["Label"] = data["Label"].apply(
+            lambda s: (
+                f'"{s}"'.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
+                if s in new_labels
+                else s
+            )
         )
-    )
     new_labels_all = set(data["Label"].unique())
     fixed_labels = list(new_labels_all - set(existing_labels))
 

--- a/backend/django/core/utils/utils_form.py
+++ b/backend/django/core/utils/utils_form.py
@@ -73,7 +73,11 @@ def clean_data_helper(
             )
 
     labels_in_data = data["Label"].dropna(inplace=False).unique()
-    if (supplied_labels is not None) and len(labels_in_data) > 0 and len(set(labels_in_data) - set(supplied_labels)) > 0:
+    if (
+        (supplied_labels is not None)
+        and len(labels_in_data) > 0
+        and len(set(labels_in_data) - set(supplied_labels)) > 0
+    ):
         just_in_data = set(labels_in_data) - set(supplied_labels)
         raise ValidationError(
             f"There are extra labels in the file which were not created in step 2: {just_in_data}"

--- a/backend/django/core/utils/utils_form.py
+++ b/backend/django/core/utils/utils_form.py
@@ -79,9 +79,16 @@ def clean_data_helper(
         and len(set(labels_in_data) - set(supplied_labels)) > 0
     ):
         just_in_data = set(labels_in_data) - set(supplied_labels)
-        raise ValidationError(
-            f"There are extra labels in the file which were not created in step 2: {just_in_data}"
-        )
+        # add a correction for label descriptions with weird characters
+        labels_in_data_fixed = [
+            f'"{s}"'.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
+            for s in just_in_data
+        ] + list(set(labels_in_data) - just_in_data)
+
+        if len(set(labels_in_data_fixed) - set(supplied_labels)) > 0:
+            raise ValidationError(
+                f"There are extra labels in the file which were not in step 2 of project creation: {just_in_data}"
+            )
 
     if "ID" in data.columns:
         # there should be no null values

--- a/backend/django/core/utils/utils_form.py
+++ b/backend/django/core/utils/utils_form.py
@@ -111,8 +111,21 @@ def clean_label_data_helper(data, existing_labels=[]):
         if field not in data.columns:
             raise ValidationError(f"File is missing required field '{field}'.")
 
-    new_labels = list(set(data["Label"].unique()) - set(existing_labels))
-    if len(new_labels) > 0 and len(existing_labels) > 0:
+    new_labels_all = set(data["Label"].unique())
+    new_labels = list(new_labels_all - set(existing_labels))
+
+    # # try adding quotes around the "new" labels and see if they match now
+    data["Label"] = data["Label"].apply(
+        lambda s: (
+            f'"{s}"'.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
+            if s in new_labels
+            else s
+        )
+    )
+    new_labels_all = set(data["Label"].unique())
+    fixed_labels = list(new_labels_all - set(existing_labels))
+
+    if len(new_labels) > 0 and len(existing_labels) > 0 and len(fixed_labels) > 0:
         raise ValidationError(
             f"New labels were found in this file: {', '.join(new_labels)}"
         )

--- a/backend/django/core/utils/utils_form.py
+++ b/backend/django/core/utils/utils_form.py
@@ -73,7 +73,7 @@ def clean_data_helper(
             )
 
     labels_in_data = data["Label"].dropna(inplace=False).unique()
-    if len(labels_in_data) > 0 and len(set(labels_in_data) - set(supplied_labels)) > 0:
+    if (supplied_labels is not None) and len(labels_in_data) > 0 and len(set(labels_in_data) - set(supplied_labels)) > 0:
         just_in_data = set(labels_in_data) - set(supplied_labels)
         raise ValidationError(
             f"There are extra labels in the file which were not created in step 2: {just_in_data}"

--- a/backend/django/core/views/frontend.py
+++ b/backend/django/core/views/frontend.py
@@ -176,7 +176,9 @@ class ProjectCreateWizard(LoginRequiredMixin, SessionWizardView):
 
         if step == "data":
             all_labels = self.get_cleaned_data_for_step("labels").get("label_data_file")
-            kwargs["labels"] = all_labels["Label"].tolist()
+            if all_labels is not None:
+                all_labels = all_labels["Label"].tolist()
+            kwargs["labels"] = all_labels
             external_data = self.get_cleaned_data_for_step("external")
             if "engine_database" in external_data:
                 kwargs["database_type"] = external_data["database_type"]
@@ -261,10 +263,10 @@ class ProjectCreateWizard(LoginRequiredMixin, SessionWizardView):
         proj = form_dict["project"]
         labels = form_dict["labels"]
         permissions = form_dict["permissions"]
-        advanced = form_dict["advanced"]
+        codebook_data = form_dict["codebook"]
         external = form_dict["external"]
         data = form_dict["data"]
-        codebook_data = form_dict["codebook"]
+        advanced = form_dict["advanced"]
 
         with transaction.atomic():
             # Project

--- a/backend/django/core/views/frontend.py
+++ b/backend/django/core/views/frontend.py
@@ -178,6 +178,7 @@ class ProjectCreateWizard(LoginRequiredMixin, SessionWizardView):
             all_labels = self.get_cleaned_data_for_step("labels").get("label_data_file")
             if all_labels is not None:
                 all_labels = all_labels["Label"].tolist()
+
             kwargs["labels"] = all_labels
             external_data = self.get_cleaned_data_for_step("external")
             if "engine_database" in external_data:

--- a/backend/django/core/views/frontend.py
+++ b/backend/django/core/views/frontend.py
@@ -343,15 +343,16 @@ class ProjectCreateWizard(LoginRequiredMixin, SessionWizardView):
 
             label_data = labels.cleaned_data["label_data_file"]
             label_data["Label"] = label_data["Label"].astype(str)
+            label_data["Description"] = label_data["Description"].astype(str).fillna("")
             label_data["project"] = proj_obj.pk
 
             stream = StringIO()
-            label_data[["Label", "Description", "project"]].to_csv(
+            label_data[["Label", "project", "Description"]].to_csv(
                 stream,
                 sep="\t",
                 header=False,
                 index=False,
-                columns=["Label", "Description", "project"],
+                columns=["Label", "project", "Description"],
                 escapechar="\\",
                 doublequote=False,
             )
@@ -365,8 +366,8 @@ class ProjectCreateWizard(LoginRequiredMixin, SessionWizardView):
                     null="",
                     columns=[
                         "name",
-                        "description",
                         "project_id",
+                        "description",
                     ],
                 )
 

--- a/frontend/src/actions/adminTables.js
+++ b/frontend/src/actions/adminTables.js
@@ -102,7 +102,7 @@ export const adminLabel = (dataID, labelID, projectID) => {
                 } else {
                     dispatch(getUnlabeled(projectID));
                     queryClient.invalidateQueries(["history", projectID]); // is this necessary?
-                    dispatch(getLabelCounts(projectID));
+                    //dispatch(getLabelCounts(projectID));
                     dispatch(getAdmin(projectID));
                     queryClient.invalidateQueries(["adminCounts", projectID]);
                 }

--- a/frontend/src/actions/card.js
+++ b/frontend/src/actions/card.js
@@ -74,7 +74,7 @@ export const annotateCard = (dataID, labelID, num_cards_left, start_time, projec
                     if (is_admin) {
                         dispatch(getAdmin(projectID));
                         queryClient.invalidateQueries(["adminCounts", projectID]);
-                        dispatch(getLabelCounts(projectID));
+                        //dispatch(getLabelCounts(projectID));
                     }
                 }
             });

--- a/frontend/src/actions/skew.js
+++ b/frontend/src/actions/skew.js
@@ -90,7 +90,7 @@ export const skewLabel = (dataID, labelID, projectID) => {
                     dispatch(setMessage(response.error));
                 } else {
                     dispatch(getUnlabeled(projectID));
-                    dispatch(getLabelCounts(projectID));
+                    //dispatch(getLabelCounts(projectID));
                 }
             });
     };

--- a/frontend/src/components/Skew/index.jsx
+++ b/frontend/src/components/Skew/index.jsx
@@ -38,7 +38,7 @@ class Skew extends React.Component {
     componentDidMount() {
         this.props.setFilterStr("");
         this.props.getUnlabeled();
-        this.props.getLabelCounts();
+        //this.props.getLabelCounts();
     }
 
     getText(row) {


### PR DESCRIPTION
This patch attempts to handle newlines, quotes, and tabs in input data by changing some of the arguments to the to_csv functions.

I messed around with a couple of options for bulk loading in data but the read/write csv method was 5x faster. Because of this I actually swapped the label and label metadata creation scripts over from bulk_create to the csv method as well.