### PR TITLE
fix category sorting when one of the category possibilities is null

### DIFF
--- a/backend/django/core/models.py
+++ b/backend/django/core/models.py
@@ -416,10 +416,12 @@ class LabelMetaDataField(models.Model):
         return self.field_name
 
     def get_unique_options(self):
-        unique_list = list(
-            set(self.labelmetadata_set.all().values_list("value", flat=True))
+        unique_list = (
+            self.labelmetadata_set.all()
+            .order_by("value")
+            .values_list("value", flat=True)
+            .distinct()
         )
-        unique_list.sort()
         return unique_list
 
 

--- a/backend/django/core/views/api.py
+++ b/backend/django/core/views/api.py
@@ -156,7 +156,7 @@ def download_irr_log(request, project_pk):
     for log in logs:
         label_name = log.label.name if log.label else ""
         writer.writerow(
-            [log.data.pk, log.data.text, label_name, log.profile.user, log.timestamp]
+            [log.data.upload_id, log.data.text, label_name, log.profile.user, log.timestamp]
         )
 
     return response

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -79,12 +79,17 @@ class SearchLabelsView(ListAPIView):
         filter_text = self.request.GET.get("searchString")
 
         label_category = self.request.GET.get("category")
-        if label_category and label_category != "all":
-            if label_category == "None":
-                category_label_list = LabelMetaData.objects.filter(
-                    label_metadata_field=project.category.label_metadata_field,
-                    value="nan",
-                ).values_list("label__pk", flat=True)
+        if hasattr(project, "category") and label_category != "all":
+            if label_category == "None" or label_category == "":
+                category_label_list = (
+                    LabelMetaData.objects.filter(
+                        label_metadata_field=project.category.label_metadata_field
+                    )
+                    .filter(
+                        Q(value__isnull=True) | Q(value="nan"),
+                    )
+                    .values_list("label__pk", flat=True)
+                )
             else:
                 category_label_list = LabelMetaData.objects.filter(
                     label_metadata_field=project.category.label_metadata_field,


### PR DESCRIPTION
I noticed that we get an error with the sort() call if some of the labels have nulls as their metadata value (which is allowed). Our projects right now appear to have "nan" the string which is why they haven't run into this error yet. The code is meant to handle both options. 