### PR TITLE
fix metadata editing bug

### DIFF
--- a/backend/django/core/models.py
+++ b/backend/django/core/models.py
@@ -230,6 +230,8 @@ class MetaData(models.Model):
     value = models.TextField(null=True, blank=True)
 
     def __str__(self):
+        if self.value is None:
+            return f"{str(self.metadata_field)}: "
         return f"{str(self.metadata_field)}: {self.value}"
 
 

--- a/backend/django/core/serializers.py
+++ b/backend/django/core/serializers.py
@@ -12,6 +12,7 @@ from core.models import (
     IRRLog,
     Label,
     LabelChangeLog,
+    MetaData,
     Model,
     Profile,
     Project,
@@ -73,8 +74,16 @@ class LabelSerializer(serializers.ModelSerializer):
         return base_representation
 
 
+class MetaDataSerializer(serializers.ModelSerializer):
+    field_name = serializers.CharField(source="metadata_field.field_name")
+
+    class Meta:
+        model = MetaData
+        fields = ["field_name", "value"]
+
+
 class DataSerializer(serializers.ModelSerializer):
-    metadata = serializers.StringRelatedField(many=True, read_only=True)
+    metadata = MetaDataSerializer(many=True, read_only=True)
 
     class Meta:
         model = Data

--- a/backend/django/core/views/api_annotate.py
+++ b/backend/django/core/views/api_annotate.py
@@ -200,9 +200,13 @@ def get_card_deck(request, project_pk):
     # shuffle so the irr is not all at the front
     random.shuffle(data)
 
+    data = DataSerializer(data, many=True).data
+    for d in data:
+        d["metadata"] = {c["field_name"]: str(c["value"] or "") for c in d["metadata"]}
+
     return Response(
         {
-            "data": DataSerializer(data, many=True).data,
+            "data": data,
         }
     )
 
@@ -732,7 +736,11 @@ def data_unlabeled_table(request, project_pk):
     unlabeled_data = unlabeled_data[:50]
     serialized_data = DataSerializer(unlabeled_data, many=True).data
     data = [
-        {"Text": d["text"], "metadata": d["metadata"], "ID": d["pk"]}
+        {
+            "Text": d["text"],
+            "metadata": {c["field_name"]: str(c["value"] or "") for c in d["metadata"]},
+            "ID": d["pk"],
+        }
         for d in serialized_data
     ]
     return Response({"data": data})
@@ -867,7 +875,10 @@ def data_admin_table(request, project_pk):
         potentialMessage = [x for x in messages if x["data_id"] == d.data.id]
         temp = {
             "Text": serialized_data["text"],
-            "metadata": serialized_data["metadata"],
+            "metadata": {
+                c["field_name"]: str(c["value"] or "")
+                for c in serialized_data["metadata"]
+            },
             "ID": d.data.id,
             "Reason": reason,
             "message": None if not potentialMessage else potentialMessage[0]["message"],
@@ -921,7 +932,10 @@ def recycle_bin_table(request, project_pk):
         serialized_data = DataSerializer(d.data, many=False).data
         temp = {
             "Text": serialized_data["text"],
-            "metadata": serialized_data["metadata"],
+            "metadata": {
+                c["field_name"]: str(c["value"] or "")
+                for c in serialized_data["metadata"]
+            },
             "ID": d.data.id,
         }
         data.append(temp)
@@ -1210,8 +1224,9 @@ def get_label_history(request, project_pk):
     page_data = DataSerializer(page_data, many=True).data
     # derive the metadata fields in the forms needed for the table
     page_metadata = [c.popitem("metadata")[1] for c in page_data]
+    # for each value, the column is everything up to the first : and the value is everything after
     page_metadata_formatted = [
-        {c.split(":")[0].replace(" ", "_"): c.split(":")[1] for c in inner_list}
+        {c["field_name"]: str(c["value"] or "") for c in inner_list}
         for inner_list in page_metadata
     ]
 
@@ -1229,8 +1244,7 @@ def get_label_history(request, project_pk):
 
     data_df = pd.merge(data_df, data_types_df, on="id")
     data_df["metadataIDs"] = page_data_metadata_ids
-    data_df["metadata"] = page_metadata
-    data_df["formattedMetadata"] = page_metadata_formatted
+    data_df["metadata"] = page_metadata_formatted
 
     # get the labeled data into the correct format for returning
     label_dict = {label.pk: label.name for label in labels}
@@ -1336,7 +1350,6 @@ def get_label_history(request, project_pk):
 
     # TODO: annotate uses pk while everything else uses ID. Let's fix this
     data_df["pk"] = data_df["id"]
-
     results = data_df.fillna("").to_dict(orient="records")
 
     return Response(
@@ -1364,10 +1377,21 @@ def modify_metadata_values(request, data_pk):
         {}
     """
     data = Data.objects.get(pk=data_pk)
-    metadata = MetaData.objects.filter(data_id=data.id)
+    metadata_list = MetaData.objects.filter(data_id=data.id)
     metadatas = request.data["metadatas"]
     for m in metadatas:
-        metadata = MetaData.objects.get(data_id=data.id, value=m["previous"])
-        metadata.value = m["value"]
+        if "previous" not in m.keys() or m["previous"] == "":
+            metadata = metadata_list.get(
+                metadata_field__field_name=m["key"], value__isnull=True
+            )
+        else:
+            metadata = metadata_list.get(
+                metadata_field__field_name=m["key"], value=m["previous"]
+            )
+
+        if m["value"] == "":
+            metadata.value = None
+        else:
+            metadata.value = m["value"]
         metadata.save()
     return Response({})

--- a/frontend/src/components/DataCard/DataCardMetadata.jsx
+++ b/frontend/src/components/DataCard/DataCardMetadata.jsx
@@ -8,19 +8,14 @@ import { GrayBox, H4 } from "../ui";
 const DataCardMetadata = ({ cardData, showEdit }) => {
     const { dataID, metadata: initialMetadata } = cardData;
     const { mutate } = useMetadataValue();
-    const parseMetadata = (md) => md.reduce((a, b) => {
-        const [key, value] = b.split(': ');
-        a[key] = value;
-        return a;
-    }, {});
     const [edit, setEdit] = useState(false);
 
-    const [originalMetadata, setOriginalMetadata] = useState(parseMetadata(initialMetadata));
+    const [originalMetadata, setOriginalMetadata] = useState(initialMetadata);
     const [metadata, setMetadata] = useState(originalMetadata || []);
 
     useEffect(() => {
-        setOriginalMetadata(parseMetadata(initialMetadata));
-        setMetadata(parseMetadata(initialMetadata) || []);
+        setOriginalMetadata(initialMetadata);
+        setMetadata(initialMetadata || []);
     }, [initialMetadata]);
 
     const handleSubmit = (event) => {

--- a/frontend/src/components/DataCard/DataCardMetadataOld.jsx
+++ b/frontend/src/components/DataCard/DataCardMetadataOld.jsx
@@ -12,7 +12,7 @@ const DataCardMetadata = ({ card }) => {
 
     const [edit, setEdit] = useState(false);
     const [originalMetadata, setOriginalMetadata] = useState((card.metadata || card.text["metadata"]).reduce((a, b) => {
-        const [key, value] = b.split(': ');
+        const [key, value] = b.replace(": ",":").split(':');
         a[key] = value;
         return a;
     }, {}));

--- a/frontend/src/components/RecycleBin/index.jsx
+++ b/frontend/src/components/RecycleBin/index.jsx
@@ -43,29 +43,11 @@ class RecycleBin extends React.Component {
         this.props.getDiscarded();
     }
 
-    getText(row) {
-        if (row.row["metadata"].length == 0) {
-            return <p></p>;
-        } else {
-            return (
-                <div>
-                    <u>Respondent Data</u>
-                    {row.row["metadata"].map(val => (
-                        <p key={val}>{val}</p>
-                    ))}
-                    <u>Text to Label</u>
-                </div>
-            );
-        }
-    }
-
     getSubComponent(row) {
         const { restoreData } = this.props;
 
         return (
             <div className="sub-row">
-                {this.getText(row)}
-                <p id="disc_text">{row.row.data}</p>
                 <DataCard 
                     data={row.original}
                     page={PAGES.RECYCLE}


### PR DESCRIPTION
This fixes two bugs:

* null metadata values being rendered as "None" and then throwing an error if edited
* metadata field names and values now won't have weird behavior if they contain colons ":"

This mostly meant fixing the metadata serializer to return the objects instead of a <key>:<vlue> string and then updating all of the places that use that serializer to account for that. 